### PR TITLE
Fix compilation issues.

### DIFF
--- a/src/lib/xpost_compat.c
+++ b/src/lib/xpost_compat.c
@@ -96,6 +96,8 @@ void *alloca (size_t);
 #endif
 
 #include "xpost_compat.h"
+#include "xpost.h"
+#include "xpost_log.h"
 
 /*
    Enable keyboard echo on terminal (console) input

--- a/src/lib/xpost_operator.c
+++ b/src/lib/xpost_operator.c
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <stdlib.h> /* NULL */
 #include <string.h> /* memcpy */
+#include <stdint.h> /* uintptr_t */
 
 #include "xpost.h"
 #include "xpost_log.h"


### PR DESCRIPTION
xpost_compat.c: include logging header to access logigng functions used.
xpost_operator.c: include header needed for uintptr_t