### PR TITLE
Fix for failed initialization 

### DIFF
--- a/src/lib/xpost_font.c
+++ b/src/lib/xpost_font.c
@@ -79,9 +79,9 @@ xpost_font_init(void)
         _xpost_font_fc_config = FcInitLoadConfigAndFonts();
         if (_xpost_font_fc_config == NULL)
             XPOST_LOG_ERR("cannot load Fc config and fonts");
+# endif
 
         return 1;
-# endif
     }
 
     return 0;


### PR DESCRIPTION
Which happens, if freetype is available but fontconfig is not.

Otherwise **xpost** fails with `Fail to initialize xpost`.