### PR TITLE
move realpath() implementation to platform-specific files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,7 @@ AC_CANONICAL_HOST
 
 have_win32="no"
 have_cygwin="no"
+have_osx="no"
 case "$host_os" in
    mingw*)
       have_win32="yes"
@@ -139,9 +140,13 @@ case "$host_os" in
    cygwin*)
       have_cygwin="yes"
    ;;
+   osx*)
+      have_osx="yes"
+   ;;
 esac
 
 AM_CONDITIONAL([HAVE_WIN32], [test "x${have_win32}" = "xyes"])
+AM_CONDITIONAL([HAVE_OSX], [test "x${have_osx}" = "xyes"])
 
 
 ### Checks for programs

--- a/src/lib/Makefile.mk
+++ b/src/lib/Makefile.mk
@@ -105,14 +105,18 @@ endif
 if HAVE_WIN32
 src_lib_libxpost_la_SOURCES += \
 src/lib/xpost_dev_win32.c \
-src/lib/xpost_dev_win32.h
+src/lib/xpost_dev_win32.h \
+src/lib/xpost_compat_win32.c
+else
+src/lib/xpost_compat_posix.c
 endif
 
 
 src_lib_libxpost_la_CPPFLAGS = \
 -DPACKAGE_DATA_DIR=\"$(pkgdatadir)\" \
 -DPACKAGE_INSTALL_DIR=\"$(prefix)/\" \
--DXPOST_BUILD
+-DXPOST_BUILD \
+-D_POSIX_C_SOURCE=200809L
 
 src_lib_libxpost_la_CFLAGS = \
 @XPOST_LIB_CFLAGS@ \

--- a/src/lib/Makefile.mk
+++ b/src/lib/Makefile.mk
@@ -108,7 +108,13 @@ src/lib/xpost_dev_win32.c \
 src/lib/xpost_dev_win32.h \
 src/lib/xpost_compat_win32.c
 else
+if HAVE_OSX
+src_lib_libxpost_la_SOURCES += \
+src/lib/xpost_compat_osx.c
+else
+src_lib_libxpost_la_SOURCES += \
 src/lib/xpost_compat_posix.c
+endif
 endif
 
 

--- a/src/lib/xpost_compat.c
+++ b/src/lib/xpost_compat.c
@@ -527,13 +527,3 @@ xpost_module_path_get(int (*fp)(void), char *buf, unsigned int size)
 
     return 0;
 }
-
-char *
-xpost_realpath(const char *path, char *resolved_path)
-{
-#ifdef _WIN32
-    return _fullpath(resolved_path, path, XPOST_PATH_MAX);
-#else
-    return realpath(path, resolved_path);
-#endif
-}

--- a/src/lib/xpost_compat.h
+++ b/src/lib/xpost_compat.h
@@ -120,7 +120,7 @@ void xpost_glob_free(glob_t *pglob);
 
 unsigned char xpost_module_path_get(int (*fp)(void), char *buf, unsigned int size);
 
-char *xpost_realpath(const char *path, char *resolved_path);
+char *xpost_realpath(const char *path);
 
 /**
  * @}

--- a/src/lib/xpost_compat_osx.c
+++ b/src/lib/xpost_compat_osx.c
@@ -1,0 +1,50 @@
+/*
+ * Xpost - a Level-2 Postscript interpreter
+ * Copyright (C) 2013-2024, Michael Joshua Ryan
+ * Copyright (C) 2013-2024, Vincent Torri
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the Xpost software product nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "xpost_compat.h"
+
+char *
+xpost_realpath(const char *path)
+{
+    char resolved_path[PATH_MAX];
+
+    if (!path || !*path)
+        return NULL;
+
+    if (!realpath(path, resolved_path))
+        return NULL;
+
+    return strdup(resolved_path);
+}

--- a/src/lib/xpost_compat_posix.c
+++ b/src/lib/xpost_compat_posix.c
@@ -1,0 +1,53 @@
+/*
+ * Xpost - a Level-2 Postscript interpreter
+ * Copyright (C) 2013-2024, Michael Joshua Ryan
+ * Copyright (C) 2013-2024, Vincent Torri
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the Xpost software product nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+
+#include "xpost_compat.h"
+
+char *
+xpost_realpath(const char *path)
+{
+    char *resolved_path;
+
+    if (!path || !*path)
+        return NULL;
+
+    resolved_path = realpath(path, NULL);
+    if (!resolved_path)
+        return NULL;
+
+    resolved_path = realpath(path, resolved_path);
+    if (!resolved_path)
+        return NULL;
+
+    return resolved_path;
+}

--- a/src/lib/xpost_compat_win32.c
+++ b/src/lib/xpost_compat_win32.c
@@ -1,0 +1,63 @@
+/*
+ * Xpost - a Level-2 Postscript interpreter
+ * Copyright (C) 2013-2016, Michael Joshua Ryan
+ * Copyright (C) 2013-2016, Vincent Torri
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the Xpost software product nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+
+#include <windows.h>
+
+#include "xpost_compat.h"
+
+char *
+xpost_realpath(const char *path)
+{
+    char *resolved_path;
+    DWORD sz = 0UL;
+
+    if (!path || !*path)
+        return NULL;
+
+    sz = GetFullPathName(path, 0UL, NULL, NULL);
+    if (sz == 0UL)
+        return NULL;
+
+    resolved_path = malloc(sz * sizeof(char));
+    if (!resolved_path)
+        return NULL;
+
+    sz = GetFullPathName(path, sz, resolved_path, NULL);
+    if (sz == 0UL)
+    {
+        free(resolved_path);
+        return NULL;
+    }
+
+    return resolved_path;
+}

--- a/src/lib/xpost_main.c
+++ b/src/lib/xpost_main.c
@@ -68,7 +68,7 @@
 static int _xpost_init_count = 0;
 static double _xpost_start_time = 0.0;
 static char _xpost_lib_dir[XPOST_PATH_MAX];
-static char _xpost_data_dir[XPOST_PATH_MAX];
+static char *_xpost_data_dir = NULL;
 
 /*============================================================================*
  *                                 Global                                     *
@@ -88,7 +88,6 @@ XPAPI int
 xpost_init(void)
 {
     char tmp1[XPOST_PATH_MAX];
-    char tmp2[XPOST_PATH_MAX];
 #ifdef HAVE_GETTIMEOFDAY
     struct timeval tv;
 #endif
@@ -109,9 +108,12 @@ xpost_init(void)
     l = strlen(_xpost_lib_dir);
     memcpy(tmp1, _xpost_lib_dir, l);
     memcpy(tmp1 + l, "/../share/xpost", sizeof("/../share/xpost"));
-    xpost_realpath(tmp1, tmp2);
-    l = strlen(tmp2) + 1;
-    memcpy(_xpost_data_dir, tmp2, l);
+    _xpost_data_dir = xpost_realpath(tmp1);
+    if (!_xpost_data_dir)
+        return --_xpost_init_count;
+
+    XPOST_LOG_ERR("Init: libdir : '%s'.", _xpost_lib_dir);
+    XPOST_LOG_ERR("Init: datadir: '%s'.", _xpost_data_dir);
 
     if (!xpost_memory_init())
         return --_xpost_init_count;
@@ -152,6 +154,7 @@ xpost_quit(void)
 
     xpost_font_quit();
     xpost_log_quit();
+    free(_xpost_data_dir);
 
     return _xpost_init_count;
 }


### PR DESCRIPTION
Also use POSIX 2008 to add malloc-feature of `realpath()`. Need to be checked on OS X