### PR TITLE
Build parts: LTO for release builds, and warning cleanups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -434,6 +434,8 @@ xpost_lib_ldflags="-fdata-sections -ffunction-sections"
 
 if test "x${enable_release}" = "xno" ; then
    xpost_lib_cflags="${xpost_lib_cflags} -g3 -ggdb3 -O2"
+else
+   xpost_lib_cflags="${xpost_lib_cflags} -O3"
 fi
 
 AC_SUBST([XPOST_TEST_CPPFLAGS])
@@ -442,6 +444,17 @@ if test "x${no_cflags}" = "xyes" ; then
    XPOST_CHECK_C_COMPILER_FLAGS([XPOST_LIB], [${xpost_lib_cflags}])
 fi
 XPOST_CHECK_LINKER_FLAGS([XPOST_LIB], [${xpost_lib_ldflags}])
+
+# Release builds enable link-time optimization. The flags are checked on their
+# own (as a literal list, so an unsupported one degrades per-flag rather than
+# dropping the base flags above) and only when the user has not supplied CFLAGS,
+# which would otherwise mean the user controls optimization. The interpreter
+# lives in the library, so LTO there is what matters; -fno-semantic-interposition
+# lets the optimizer inline calls to the library's own globals across units.
+if test "x${enable_release}" = "xyes" && test "x${no_cflags}" = "xyes" ; then
+   XPOST_CHECK_C_COMPILER_FLAGS([XPOST_LIB], [-flto -fno-semantic-interposition])
+   XPOST_CHECK_LINKER_FLAGS([XPOST_LIB], [-flto -fno-semantic-interposition])
+fi
 
 if test "x${no_cflags}" = "xyes" ; then
    XPOST_CHECK_C_COMPILER_FLAGS([XPOST_BIN], [-std=c99 -pedantic-errors -Wall -Wextra -Wshadow -Wdeclaration-after-statement -Wmissing-prototypes -Wstrict-prototypes -Wpointer-arith -Wno-missing-field-initializers -Winline])

--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,24 @@ config_h = configuration_data()
 
 cc = meson.get_compiler('c')
 
+# Release builds enable link-time optimization by default: it inlines the hot
+# cross-translation-unit interpreter accessors and is the single largest
+# speedup. debug and debugoptimized builds stay LTO-free for fast compiles, so
+# a release build is the way to opt in and any other buildtype opts out.
+if get_option('buildtype') == 'release'
+  lto_flags = cc.get_supported_arguments('-flto=auto')
+  if lto_flags.length() == 0
+    lto_flags = cc.get_supported_arguments('-flto')
+  endif
+  # Without -fno-semantic-interposition a shared library assumes its own global
+  # functions may be interposed at runtime, so the optimizer cannot inline calls
+  # to them across translation units even under LTO -- which is exactly the
+  # inlining of the hot object accessors we want.
+  lto_flags += cc.get_supported_arguments('-fno-semantic-interposition')
+  add_project_arguments(lto_flags, language: 'c')
+  add_project_link_arguments(lto_flags, language: 'c')
+endif
+
 splint = find_program('splint', required: false)
 
 if splint.found()

--- a/src/lib/xpost_dev_xcb.c
+++ b/src/lib/xpost_dev_xcb.c
@@ -375,6 +375,9 @@ int _getpix(Xpost_Context *ctx,
     Xpost_Object privatestr;
     PrivateData private;
 
+    (void)x;
+    (void)y;
+
     /* load private data struct from string */
     privatestr = xpost_dict_get(ctx, devdic, namePrivate);
     if (xpost_object_get_type(privatestr) == invalidtype)

--- a/src/lib/xpost_interpreter.c
+++ b/src/lib/xpost_interpreter.c
@@ -316,7 +316,7 @@ int evalquit(Xpost_Context *ctx)
 static
 int evalpop(Xpost_Context *ctx)
 {
-    if (!xpost_object_get_type(xpost_stack_pop(ctx->lo, ctx->es)) == invalidtype)
+    if (xpost_object_get_type(xpost_stack_pop(ctx->lo, ctx->es)) == invalidtype)
         return stackunderflow;
     return 0;
 }

--- a/src/lib/xpost_memory.c
+++ b/src/lib/xpost_memory.c
@@ -316,7 +316,7 @@ xpost_memory_file_grow(Xpost_Memory_File *mem,
     sz += mem->max * 1.5;
 
     XPOST_LOG_INFO("grow memory file%s%s (old: %d  new: %d)",
-                   mem->fname ? " for " : "", mem->fname ? mem->fname : "",
+                   mem->fname[0] ? " for " : "", mem->fname[0] ? mem->fname : "",
                    mem->max, sz);
 
 #ifdef _WIN32
@@ -506,7 +506,7 @@ xpost_memory_file_dump(const Xpost_Memory_File *mem)
 
     if ((u-1)%16 != 0)
     { /* did not print in the last iteration of the loop */
-        for (v = u; u%16 != 0; v++)
+        for (v = u; v%16 != 0; v++)
         {
             XPOST_LOG_DUMP("   ");
         }

--- a/src/lib/xpost_op_type.c
+++ b/src/lib/xpost_op_type.c
@@ -189,7 +189,7 @@ int Scvi(Xpost_Context *ctx,
         free(t);
         return limitcheck;
     }
-    if (dbl >= LONG_MAX || dbl <= LONG_MIN){
+    if (dbl >= (double)LONG_MAX || dbl <= (double)LONG_MIN){
         free(t);
         return limitcheck;
     }

--- a/src/lib/xpost_operator.c
+++ b/src/lib/xpost_operator.c
@@ -138,6 +138,7 @@ int _stack_float(Xpost_Context *ctx)
             return stackunderflow;
         case integertype:
             xpost_stack_topdown_replace(ctx->lo, ctx->os, 0, s0 = _promote_integer_to_real(s0));
+            /* fallthrough */
         case realtype:
             return 0;
         default:
@@ -214,6 +215,7 @@ int _stack_float_float(Xpost_Context *ctx)
             return stackunderflow;
         case integertype:
             xpost_stack_topdown_replace(ctx->lo, ctx->os, 0, s0 = _promote_integer_to_real(s0));
+            /* fallthrough */
         case realtype:
             s1 = xpost_stack_topdown_fetch(ctx->lo, ctx->os, 1);
             switch(xpost_object_get_type(s1))
@@ -222,6 +224,7 @@ int _stack_float_float(Xpost_Context *ctx)
                     return stackunderflow;
                 case integertype:
                     xpost_stack_topdown_replace(ctx->lo, ctx->os, 1, s1 = _promote_integer_to_real(s1));
+                    /* fallthrough */
                 case realtype:
                     return 0;
                 default:
@@ -685,7 +688,7 @@ int xpost_operator_exec(Xpost_Context *ctx,
     switch(sp[i].in)
     {
         case 0:
-            ret = sp[i].fp(ctx); break;
+            ret = ((int(*)(Xpost_Context*))sp[i].fp)(ctx); break;
         case 1:
             ret = ((int(*)(Xpost_Context*,Xpost_Object))sp[i].fp)
                 (ctx, hold->data[0]); break;


### PR DESCRIPTION
This is the first of the two PRs requested in #62 ([comment](https://github.com/luser-dr00g/xpost/pull/62#issuecomment-5036630920)): just the build parts, with the minimal source changes that go with them, including the LTO work.

**`perf(build): enable LTO for release builds`** — a release build now turns on link-time optimization automatically in both build systems. As discussed in the review thread on #62, `-fno-semantic-interposition` is paired with `-flto` because in a shared-library build `-flto` alone buys almost nothing: the optimizer must be allowed to inline calls to the library's own globals across translation units. meson gets it via `--buildtype=release` (portably, through `cc.get_supported_arguments`, so an unsupported flag degrades gracefully); autoconf via `--enable-release` when the user has not supplied their own CFLAGS. The default meson buildtype (debug) is unchanged, and output is byte-identical. On a wider benchmark suite LTO roughly halves render and interpretation times (e.g. a full-page render drops from 0.54s to 0.28s).

**`cleanup: build without warnings on gcc and clang`** — quiets the `-Wall -Wextra` set and clang's additional checks (fall-through annotations, unused parameters, a prototype for the zero-argument operator call, casts where a real is range-checked against `LONG_MAX`/`LONG_MIN`). Three of the warnings exposed latent bugs: a memory-dump pad loop that tested a fixed counter in its condition (an infinite loop if reached), a log test on a filename array's address rather than its first byte, and an operator-precedence slip in `evalpop` (`!type == invalidtype`) that inverted the test so that executing a null object raised `stackunderflow` instead of being the no-op the PLRM specifies (§3.5.5). Verified before/after: `null cvx exec` errors on master and proceeds silently with this commit.

Both commits build and pass the test suite under meson (debug and release buildtypes) and autotools (`--enable-release`), with gcc and clang warning-free at the tip.
