### PR TITLE
Device performance: compiled FillRect fast paths, and a no-op null-device FillPoly

### DIFF
--- a/data/device.ps
+++ b/data/device.ps
@@ -27,6 +27,13 @@ DEVICE begin
     % cost of a page to discard every span
     currentdict /NoOutput known not {
         /FillPoly /.fillpoly load def
+        % grayscale array-of-strings devices (PGMIMAGE) get the compiled
+        % FillRect too; erasepage clears the page through it. Fetch the
+        % value with get: some devices store nativecolorspace as an
+        % executable name, which a bare reference would try to execute.
+        currentdict /nativecolorspace get /DeviceGray eq {
+            /FillRect /.fillrectgray load def
+        } if
     } if
 end
 

--- a/data/device.ps
+++ b/data/device.ps
@@ -21,10 +21,13 @@ newdefaultdevice % defined in xpost_interpreter.c:setlocalconfig()
 DEVICE begin
     /defaultmatrix [ 1 0 0 -1 0 height ] def
 
-    % override ps fillpoly with operator
-    %/FillPoly load type /operatortype ne { % unless already overridden.
+    % override the class's scanline FillPoly with the compiled
+    % rasterizer, except where the device declares it draws nothing:
+    % rasterizing into the null device would burn the whole render
+    % cost of a page to discard every span
+    currentdict /NoOutput known not {
         /FillPoly /.fillpoly load def
-    %} if
+    } if
 end
 
 /flushpage {

--- a/data/nulldev.ps
+++ b/data/nulldev.ps
@@ -36,6 +36,7 @@
 /NULLDEV <<
     /nativecolorspace /DeviceGray
     /dimensions [0 0]
+    /NoOutput true % this device draws nothing: keep its no-op methods
 
     /.copydict {
         dup length dict copy

--- a/src/lib/xpost_dev_generic.c
+++ b/src/lib/xpost_dev_generic.c
@@ -73,6 +73,7 @@ static Xpost_Object nameexec;
 static Xpost_Object namerepeat;
 static Xpost_Object namecvx;
 static Xpost_Object nameRbracket;
+static Xpost_Object nameImgData;
 
 char *xpost_device_get_filename(Xpost_Context *ctx, Xpost_Object devdic)
 {
@@ -524,6 +525,69 @@ int _fillpoly(Xpost_Context *ctx,
     return 0;
 }
 
+/* Fast FillRect for grayscale (DeviceGray) array-of-strings devices such as
+   PGMIMAGE. Writes the ImgData row strings directly rather than looping over
+   PutPix in PostScript; erasepage clears the whole page through FillRect, so
+   the per-pixel interpreter overhead otherwise dominates page emission.
+   Mirrors PGMIMAGE's FillRect/PutPix handling exactly: value scaled by 255 and
+   truncated to a byte, coordinates floored, negative extents normalised,
+   inclusive end coordinates, and bounds clipping (rows via ImgData length,
+   columns via each row string's length). */
+static
+int _fillrectgray(Xpost_Context *ctx,
+                  Xpost_Object val,
+                  Xpost_Object x,
+                  Xpost_Object y,
+                  Xpost_Object w,
+                  Xpost_Object h,
+                  Xpost_Object devdic)
+{
+    Xpost_Object imgdata, row;
+    double dx, dy, dw, dh;
+    int height, iy, iy0, iy1, ix0, ix1;
+    unsigned char b;
+
+    imgdata = xpost_dict_get(ctx, devdic, nameImgData);
+    if (xpost_object_get_type(imgdata) != arraytype)
+        return undefined;
+    height = imgdata.comp_.sz;
+
+    /* value -> byte, matching PGMIMAGE PutPix "255 mul cvi put" */
+    b = (unsigned char)(int)((xpost_object_get_type(val) == realtype
+                              ? val.real_.val : (double)val.int_.val) * 255.0);
+
+    dx = xpost_object_get_type(x) == realtype ? x.real_.val : (double)x.int_.val;
+    dy = xpost_object_get_type(y) == realtype ? y.real_.val : (double)y.int_.val;
+    dw = xpost_object_get_type(w) == realtype ? w.real_.val : (double)w.int_.val;
+    dh = xpost_object_get_type(h) == realtype ? h.real_.val : (double)h.int_.val;
+
+    /* normalise negative extents, then form inclusive end coords */
+    if (dw < 0) { dw = -dw; dx -= dw; }
+    if (dh < 0) { dh = -dh; dy -= dh; }
+    ix0 = (int)floor(dx);
+    iy0 = (int)floor(dy);
+    ix1 = (int)floor(dx + dw);
+    iy1 = (int)floor(dy + dh);
+
+    /* clip rows to the device */
+    if (iy0 < 0) iy0 = 0;
+    if (iy1 > height - 1) iy1 = height - 1;
+
+    for (iy = iy0; iy <= iy1; iy++)
+    {
+        int width, cx0, cx1;
+        row = xpost_array_get(ctx, imgdata, iy);
+        width = row.comp_.sz;
+        cx0 = ix0 < 0 ? 0 : ix0;
+        cx1 = ix1 > width - 1 ? width - 1 : ix1;
+        if (cx0 <= cx1)
+            memset(xpost_string_get_pointer(ctx, row) + cx0, b,
+                   (size_t)(cx1 - cx0 + 1));
+    }
+
+    return 0;
+}
+
 int xpost_oper_init_generic_device_ops(Xpost_Context *ctx,
                                        Xpost_Object sd)
 {
@@ -538,7 +602,11 @@ int xpost_oper_init_generic_device_ops(Xpost_Context *ctx,
 
     op = xpost_operator_cons(ctx, ".yxsort", (Xpost_Op_Func)_yxsort, 0, 1, arraytype); INSTALL;
     op = xpost_operator_cons(ctx, ".fillpoly", (Xpost_Op_Func)_fillpoly, 0, 2, arraytype, dicttype); INSTALL;
+    op = xpost_operator_cons(ctx, ".fillrectgray", (Xpost_Op_Func)_fillrectgray, 0, 6,
+            numbertype, numbertype, numbertype, numbertype, numbertype, dicttype); INSTALL;
     if (xpost_object_get_type((namewidth = xpost_name_cons(ctx, "width"))) == invalidtype)
+        return VMerror;
+    if (xpost_object_get_type((nameImgData = xpost_name_cons(ctx, "ImgData"))) == invalidtype)
         return VMerror;
     if (xpost_object_get_type((namenativecolorspace = xpost_name_cons(ctx, "nativecolorspace"))) == invalidtype)
         return VMerror;

--- a/src/lib/xpost_dev_png.c
+++ b/src/lib/xpost_dev_png.c
@@ -320,6 +320,63 @@ int _putpix(Xpost_Context *ctx,
     return 0;
 }
 
+/* C fast-path for the base-class PS FillRect: fills the buffer directly
+   rather than looping over PutPix per pixel. The only caller is erasepage
+   (full-page clear), which dominates page-emission time when done in PS. */
+static
+int _fillrect(Xpost_Context *ctx,
+              Xpost_Object red,
+              Xpost_Object green,
+              Xpost_Object blue,
+              Xpost_Object x,
+              Xpost_Object y,
+              Xpost_Object w,
+              Xpost_Object h,
+              Xpost_Object devdic)
+{
+    Xpost_Object privatestr;
+    PrivateData private;
+    Xpost_Png_Pixel pixel;
+    int ix, iy, x0, y0, x1, y1;
+
+    /* fold numbers as PutPix does: colours scaled to 0..255, coords truncated */
+    pixel.red   = (unsigned char)((xpost_object_get_type(red)   == realtype ? red.real_.val   * 255.0 : red.int_.val   * 255));
+    pixel.green = (unsigned char)((xpost_object_get_type(green) == realtype ? green.real_.val * 255.0 : green.int_.val * 255));
+    pixel.blue  = (unsigned char)((xpost_object_get_type(blue)  == realtype ? blue.real_.val  * 255.0 : blue.int_.val  * 255));
+    x0 = xpost_object_get_type(x) == realtype ? (int)x.real_.val : x.int_.val;
+    y0 = xpost_object_get_type(y) == realtype ? (int)y.real_.val : y.int_.val;
+    x1 = xpost_object_get_type(w) == realtype ? (int)w.real_.val : w.int_.val;
+    y1 = xpost_object_get_type(h) == realtype ? (int)h.real_.val : h.int_.val;
+
+    /* normalise negative extents, then form inclusive end coords (as PS FillRect) */
+    if (x1 < 0) { x1 = -x1; x0 -= x1; }
+    if (y1 < 0) { y1 = -y1; y0 -= y1; }
+    x1 += x0;
+    y1 += y0;
+
+    privatestr = xpost_dict_get(ctx, devdic, namePrivate);
+    if (xpost_object_get_type(privatestr) == invalidtype)
+        return undefined;
+    xpost_memory_get(xpost_context_select_memory(ctx, privatestr),
+                     xpost_object_get_ent(privatestr), 0,
+                     sizeof(private), &private);
+
+    /* clip to device bounds */
+    if (x0 < 0) x0 = 0;
+    if (y0 < 0) y0 = 0;
+    if (x1 > private.width  - 1) x1 = private.width  - 1;
+    if (y1 > private.height - 1) y1 = private.height - 1;
+
+    for (iy = y0; iy <= y1; iy++)
+    {
+        Xpost_Png_Pixel *row = private.buf->data + iy * private.width;
+        for (ix = x0; ix <= x1; ix++)
+            row[ix] = pixel;
+    }
+
+    return 0;
+}
+
 static
 int _emit(Xpost_Context *ctx,
           Xpost_Object devdic)
@@ -469,6 +526,14 @@ int loadpngdevicecont(Xpost_Context *ctx,
             numbertype, numbertype,
             dicttype);
     ret = xpost_dict_put(ctx, classdic, xpost_name_cons(ctx, "PutPix"), op);
+    if (ret)
+        return ret;
+
+    op = xpost_operator_cons(ctx, "pngFillRect", (Xpost_Op_Func)_fillrect, 0, 8,
+            numbertype, numbertype, numbertype,
+            numbertype, numbertype, numbertype, numbertype,
+            dicttype);
+    ret = xpost_dict_put(ctx, classdic, xpost_name_cons(ctx, "FillRect"), op);
     if (ret)
         return ret;
 

--- a/src/lib/xpost_dev_raster.c
+++ b/src/lib/xpost_dev_raster.c
@@ -379,6 +379,88 @@ int _putpix(Xpost_Context *ctx,
     return 0;
 }
 
+/* C fast-path for the base-class per-pixel FillRect. erasepage clears the
+   whole page through FillRect, so this is on the hot path for every page. */
+static
+int _fillrect(Xpost_Context *ctx,
+              Xpost_Object red,
+              Xpost_Object green,
+              Xpost_Object blue,
+              Xpost_Object x,
+              Xpost_Object y,
+              Xpost_Object w,
+              Xpost_Object h,
+              Xpost_Object devdic)
+{
+    Xpost_Object privatestr;
+    PrivateData private;
+    int ix, iy, x0, y0, x1, y1, r, g, b, stride;
+
+    /* fold as PutPix does: colours scaled to 0..255, coords truncated */
+    r = (int)(xpost_object_get_type(red)   == realtype ? red.real_.val   * 255.0 : red.int_.val   * 255);
+    g = (int)(xpost_object_get_type(green) == realtype ? green.real_.val * 255.0 : green.int_.val * 255);
+    b = (int)(xpost_object_get_type(blue)  == realtype ? blue.real_.val  * 255.0 : blue.int_.val  * 255);
+    x0 = xpost_object_get_type(x) == realtype ? (int)x.real_.val : x.int_.val;
+    y0 = xpost_object_get_type(y) == realtype ? (int)y.real_.val : y.int_.val;
+    x1 = xpost_object_get_type(w) == realtype ? (int)w.real_.val : w.int_.val;
+    y1 = xpost_object_get_type(h) == realtype ? (int)h.real_.val : h.int_.val;
+
+    /* normalise negative extents, then form inclusive end coords */
+    if (x1 < 0) { x1 = -x1; x0 -= x1; }
+    if (y1 < 0) { y1 = -y1; y0 -= y1; }
+    x1 += x0;
+    y1 += y0;
+
+    privatestr = xpost_dict_get(ctx, devdic, namePrivate);
+    if (xpost_object_get_type(privatestr) == invalidtype)
+        return undefined;
+    xpost_memory_get(xpost_context_select_memory(ctx, privatestr),
+                     xpost_object_get_ent(privatestr), 0,
+                     sizeof(private), &private);
+
+    /* clip to device bounds */
+    if (x0 < 0) x0 = 0;
+    if (y0 < 0) y0 = 0;
+    if (x1 > private.buf->width  - 1) x1 = private.buf->width  - 1;
+    if (y1 > private.buf->height - 1) y1 = private.buf->height - 1;
+    stride = private.buf->width;
+
+#define RASTER_FILLRECT(TYPE, SET) \
+    do { \
+        TYPE pix; \
+        SET \
+        for (iy = y0; iy <= y1; iy++) \
+        { \
+            TYPE *row = (TYPE *)private.buf->data + (size_t)iy * stride; \
+            for (ix = x0; ix <= x1; ix++) \
+                row[ix] = pix; \
+        } \
+    } while (0)
+
+    switch (private.pixelformat)
+    {
+        case BGRA:
+            RASTER_FILLRECT(Xpost_Raster_BGRA_Pixel,
+                pix.blue = b; pix.green = g; pix.red = r; pix.alpha = 255;);
+            break;
+        case BGR:
+            RASTER_FILLRECT(Xpost_Raster_BGR_Pixel,
+                pix.blue = b; pix.green = g; pix.red = r;);
+            break;
+        case ARGB:
+            RASTER_FILLRECT(Xpost_Raster_ARGB_Pixel,
+                pix.alpha = 255; pix.red = r; pix.green = g; pix.blue = b;);
+            break;
+        case RGB:
+            RASTER_FILLRECT(Xpost_Raster_RGB_Pixel,
+                pix.red = r; pix.green = g; pix.blue = b;);
+            break;
+    }
+#undef RASTER_FILLRECT
+
+    return 0;
+}
+
 #endif
 
 static
@@ -595,6 +677,14 @@ int loadrasterdevicecont(Xpost_Context *ctx,
                              numbertype, numbertype,
                              dicttype);
     ret = xpost_dict_put(ctx, classdic, xpost_name_cons(ctx, "PutPix"), op);
+    if (ret)
+        return ret;
+
+    op = xpost_operator_cons(ctx, "rasterFillRect", (Xpost_Op_Func)_fillrect, 0, 8,
+                             numbertype, numbertype, numbertype,
+                             numbertype, numbertype, numbertype, numbertype,
+                             dicttype);
+    ret = xpost_dict_put(ctx, classdic, xpost_name_cons(ctx, "FillRect"), op);
     if (ret)
         return ret;
 #endif


### PR DESCRIPTION
The second PR requested in #62: performance of the output devices. Four commits, each independent of the interpreter and graphics work still queued in #62.

The theme is the aside in #47: a device that need not route every pixel through interpreted PostScript draws far faster. The base-class `FillRect` loops over a PostScript `PutPix` per pixel, and `erasepage` clears the whole page through it, so every page paid seconds of per-pixel interpreter overhead before painting anything.

- **`perf(device): keep the null device's no-op FillPoly`** — device setup unconditionally replaced every device's `FillPoly` with the compiled rasterizer, including the null device's, whose entire purpose is to draw nothing. A device now opts out by declaring `/NoOutput`, so a fill on the null device costs only its argument build.
- **`perf(png): fill rectangles in C instead of per-pixel PostScript`** — a C `FillRect` for the PNG device that writes the pixel buffer directly. A full-page render drops from 1.55s to 0.63s.
- **`perf(pgm): fill grayscale rectangles in C instead of per-pixel PostScript`** — a `.fillrectgray` operator (a `memset` per ImgData row) installed via device.ps for DeviceGray array-of-strings devices. A full-page pgm render drops from 5.80s to 1.29s; a 3600-rectangle benchmark page from 1.41s to 0.27s.
- **`perf(raster): fill rectangles in C`** — the buffer device had no compiled `FillRect` and, being a colour device, did not get the grayscale one either. A compiled `FillRect` covering its pixel formats brings page rendering into the buffer down by an order of magnitude (the `xpost_client` demo drops from 4.8s to 0.4s here).

Output is byte-identical in every case — verified per commit against master with a fill-exercise page through the pgm and png devices, and with `xpost_client`'s built-in program for the raster device. Each commit builds warning-free under meson and autotools.
