### PR TITLE
generic device: fix alloc-size warning; main: let uninstalled builds initialise

### DIFF
--- a/src/lib/xpost_dev_generic.c
+++ b/src/lib/xpost_dev_generic.c
@@ -347,6 +347,8 @@ int _fillpoly(Xpost_Context *ctx,
 
     /* extract polygon vertices from ps array */
     points = malloc(poly.comp_.sz * sizeof *points);
+    if (!points)
+        return VMerror;
     for (i = 0; i < poly.comp_.sz; i++)
     {
         Xpost_Object pair, x, y;
@@ -378,7 +380,21 @@ int _fillpoly(Xpost_Context *ctx,
             maxy = points[i].y;
     }
 
-    intersections = calloc((int)(maxy - miny), 2 * 2 * sizeof *intersections);
+    /* an empty or flat polygon spans no scanlines and paints nothing;
+       an empty one would also leave the bounding box at its sentinel
+       values, making the allocation count below hugely negative */
+    if (maxy - miny < 1)
+    {
+        free(points);
+        return 0;
+    }
+
+    intersections = calloc((size_t)(maxy - miny), 2 * 2 * sizeof *intersections);
+    if (!intersections)
+    {
+        free(points);
+        return VMerror;
+    }
 
     /* intersect polygon edges with scanlines */
     for (i = 0, j = 0; i < poly.comp_.sz - 1; i++)

--- a/src/lib/xpost_main.c
+++ b/src/lib/xpost_main.c
@@ -96,7 +96,16 @@ xpost_init(void)
     memcpy(tmp1 + l, "/../share/xpost", sizeof("/../share/xpost"));
     _xpost_data_dir = xpost_realpath(tmp1);
     if (!_xpost_data_dir)
-        return --_xpost_init_count;
+    {
+        /* An uninstalled library has no ../share/xpost neighbour for
+           realpath() to resolve. Keep the unresolved path, as
+           GetFullPathName() does on Windows: the interpreter probes
+           several candidate directories for init.ps and passes over
+           those that do not exist. */
+        _xpost_data_dir = strdup(tmp1);
+        if (!_xpost_data_dir)
+            return --_xpost_init_count;
+    }
 
     if (!xpost_memory_init())
         return --_xpost_init_count;


### PR DESCRIPTION
Fixes the `-Walloc-size-larger-than=` warning reported by @vtorri in https://github.com/luser-dr00g/xpost/pull/62#issuecomment-5068573208, and the long-standing linux CI `make check` failure.

**generic device: fix alloc-size warning for degenerate polygons in _fillpoly** — An empty polygon array leaves `_fillpoly`'s bounding box at its sentinel values, so the scanline count passed to `calloc()` is a large negative number that converts to a huge `size_t`. Return before the allocation when the polygon spans no scanlines (empty or flat) — the case where there is nothing to paint — and check the allocations that remain so out-of-memory surfaces as a `VMerror` rather than a crash. Reproduced the warning on Linux GCC and confirmed it is gone with this change; triangle-fill output through the PGM device is unchanged.

**main: survive an unresolvable data directory during initialisation** — `xpost_suite` (run by `make check`) has failed on every linux CI run with "Fail to initialize the xpost library": on POSIX, `realpath()` fails when `<libdir>/../share/xpost` does not exist, which is always the case in an uninstalled build tree, so `xpost_init()` bailed before the interpreter's `init.ps` search chain (`XPOST_DATA_DIR`, `PACKAGE_DATA_DIR`, `data`, `../data`, …) could run. Windows' `GetFullPathName()` resolves such paths lexically, which is why the msys2 `make check` passes. Keep the unresolved path on POSIX too and let the existing search chain skip nonexistent candidates. Verified that an uninstalled `xpost` binary now runs from the source root instead of failing to initialise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
