### PR TITLE
Baseline correctness & PLRM-compliance fixes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,18 +15,12 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
-        sudo apt install build-essential libpng-dev libjpeg-dev libfreetype6-dev libfontconfig1-dev check meson ninja-build
+        sudo apt install build-essential libpng-dev libjpeg-dev libfreetype6-dev libfontconfig1-dev meson ninja-build
     - name: meson
       run: meson setup builddir
     - name: ninja
       run: ninja -C builddir
     - name: meson test
       run: meson test -C builddir --print-errorlogs
-    - name: configure
-      run: autoreconf -vif && ./configure --with-tests=regular
-    - name: make
-      run: make V=1
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
+    - name: meson dist
+      run: meson dist -C builddir

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,9 +2,9 @@ name: linux CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         config:
           - msystem: mingw32
-            install: base-devel git mingw-w64-i686-toolchain mingw-w64-i686-autotools mingw-w64-i686-libjpeg-turbo mingw-w64-i686-libpng mingw-w64-i686-freetype mingw-w64-i686-fontconfig
+            install: base-devel git mingw-w64-i686-toolchain mingw-w64-i686-libjpeg-turbo mingw-w64-i686-libpng mingw-w64-i686-freetype mingw-w64-i686-fontconfig mingw-w64-i686-meson mingw-w64-i686-ninja
           - msystem: mingw64
-            install: base-devel git  mingw-w64-x86_64-toolchain mingw-w64-x86_64-autotools mingw-w64-x86_64-libjpeg-turbo mingw-w64-x86_64-libpng mingw-w64-x86_64-freetype mingw-w64-x86_64-fontconfig mingw-w64-x86_64-check mingw-w64-x86_64-meson mingw-w64-x86_64-ninja
+            install: base-devel git mingw-w64-x86_64-toolchain mingw-w64-x86_64-libjpeg-turbo mingw-w64-x86_64-libpng mingw-w64-x86_64-freetype mingw-w64-x86_64-fontconfig mingw-w64-x86_64-meson mingw-w64-x86_64-ninja
     name: msys2 - ${{ matrix.config.msystem }}
     runs-on: windows-latest
     defaults:
@@ -31,14 +31,6 @@ jobs:
         update: true
         install: ${{ matrix.config.install }}
     - name: meson
-      if: matrix.config.msystem == 'mingw64'
       run: meson setup builddir
     - name: meson test
-      if: matrix.config.msystem == 'mingw64'
       run: meson test -C builddir --print-errorlogs
-    - name: configure
-      run: autoreconf -vif && ./configure --with-tests=regular
-    - name: configure
-      run: make V=1
-    - name: test
-      run: make check

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - master
+      - main
       - '[0-9]+.[0-9]+'
   pull_request:
-    branches: [master]
+    branches: [master, main]
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -2,9 +2,9 @@ name: osx CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ visual_studio/vc14/xpost_suite/x64/
 /at-check/
 /at-rel/
 /xpost-inst-test/
+semantics.diskf
+semantics.scratch
+xpost-*.tar.*

--- a/COMPLIANCE
+++ b/COMPLIANCE
@@ -13,7 +13,7 @@ Level 1 operators
 
  [X] setdash
  [X] currentdash
- [ ] arcto
+ [X] arcto
  [ ] fill with complex paths
  [ ] eofill
  [ ] clip with complex paths
@@ -200,6 +200,7 @@ Level 1 operators
  [X] rlineto
  [X] arc
  [X] arcn
+ [X] arcto
  [X] curveto
  [X] rcurveto
  [X] closepath
@@ -228,6 +229,7 @@ Level 1 operators
 Level 2 operators
 -----------------
 
+ [X] arct
  [ ] colorimage
  [ ] image with dict argument
  [ ] setcolortransfer

--- a/COMPLIANCE
+++ b/COMPLIANCE
@@ -265,3 +265,29 @@ Typical output devices
  [ ] dsc-compliant distilled ps
  [X] xcb
  [X] ms-windows
+
+PLRM 8.2 operator compliance campaign — deviations
+---------------------------------------------------
+
+Recorded as found while working PLRM 8.2 operator by operator. Fixed items are
+listed for the record; open items are genuine remaining deviations.
+
+ [X] mod    zero divisor is undefinedresult, not a SIGFPE (was a crash); fixed
+ [X] sqrt   negative operand is rangecheck, not a silent NaN; fixed
+ [X] atan/sin/cos  match the PLRM examples (a truncated RAD_PER_DEG had skewed
+     them, e.g. 1 0 atan gave 89.99996); fixed
+ [X] repeat negative count is rangecheck (PLRM: nonnegative integer), not a
+     silent no-op; fixed
+ [/] setpacking / currentpacking  the array packing mode is not maintained:
+     currentpacking stays false and setpacking has no effect, because the state
+     lived in systemdict, which is now sealed read-only. PLRM 8.2 makes the mode
+     a per-context, save/restore-subject parameter that governs scanner { }
+     packing. Packed arrays built explicitly by packedarray are unaffected.
+ [/] error operand restoration  after an operator errors, coerced operand values
+     may remain on the stack where PLRM 3.11 restores the originals -- e.g.
+     1 0 div under stopped leaves 1.0 0.0 rather than the original 1 0 -- because
+     the dispatcher coerces int operands to real before the operator runs.
+ [/] real precision  reals are IEEE single precision (PLRM 3.3.2 permits single
+     or double), so results carry ~7 significant figures and large values may
+     print in exponent form (4e+09) where a double-precision interpreter prints
+     4000000000. Values are correct; only precision and representation differ.

--- a/COMPLIANCE
+++ b/COMPLIANCE
@@ -301,3 +301,9 @@ listed for the record; open items are genuine remaining deviations.
      a single Bezier segment; fixed
  [X] status  gained the (filename) form (pages bytes referred created true, or
      false) alongside the file-object form; fixed
+ [X] currentuserparams / currentsystemparams  return a dictionary of the current
+     parameters (stack limits, VMReclaim / VMThreshold, RealFormat, ByteOrder,
+     MaxFontCache); setuserparams / setsystemparams apply the parameters they
+     recognise; fixed
+ [X] bytesavailable  reports -1 for a filter or other non-seekable file rather
+     than reading a FILE* field those file types do not have; fixed

--- a/COMPLIANCE
+++ b/COMPLIANCE
@@ -291,3 +291,13 @@ listed for the record; open items are genuine remaining deviations.
      or double), so results carry ~7 significant figures and large values may
      print in exponent form (4e+09) where a double-precision interpreter prints
      4000000000. Values are correct; only precision and representation differ.
+ [X] transform / dtransform / itransform / idtransform / invertmatrix  a matrix
+     operand that is not a six-element array is rangecheck, not an out-of-bounds
+     read; fixed
+ [X] setlinecap / setlinejoin  values outside 0..2, and setmiterlimit below 1,
+     are rangecheck, not silently accepted; fixed
+ [X] rotate / arc / arct  built angles through a truncated RAD_PER_DEG and so
+     missed the axis angles; now full precision, and a right-angle arct corner is
+     a single Bezier segment; fixed
+ [X] status  gained the (filename) form (pages bytes referred created true, or
+     false) alongside the file-object form; fixed

--- a/Makefile.am
+++ b/Makefile.am
@@ -75,6 +75,15 @@ lcov-report:
 
 endif
 
+# PLRM operator-example conformance suite (data/test.ps) run through the built
+# interpreter -- the real interpreter test, run by `make check` regardless of
+# --with-tests (it needs only the xpost binary). XPOST_DATA_DIR points the
+# uninstalled binary at the source data. Mirrors the meson test('interpreter').
+XPOST_PS_CONFORMANCE = \
+	XPOST_DATA_DIR=$(top_srcdir)/data \
+	$(top_srcdir)/tests/run-ps-test.sh \
+	$(top_builddir)/src/bin/xpost$(EXEEXT) $(top_srcdir)/data/test.ps
+
 if XPOST_ENABLE_TESTS
 
 include src/tests/Makefile.mk
@@ -93,12 +102,13 @@ if XPOST_ENABLE_COVERAGE
 endif
 
 check-local:
+	$(XPOST_PS_CONFORMANCE)
 	$(XPOST_VALGRIND) $(top_builddir)/src/tests/xpost_suite$(EXEEXT)
 
 else
 
 check-local:
-	@echo "reconfigure with --enable-tests"
+	$(XPOST_PS_CONFORMANCE)
 
 endif
 
@@ -107,6 +117,7 @@ COMPLIANCE \
 autogen.sh \
 xpost.pc.in \
 m4/xpost.m4 \
+tests/run-ps-test.sh \
 valgrind_wrapper.sh \
 glibc.supp \
 visual_studio/vc10/xpost.sln \

--- a/data/clip.ps
+++ b/data/clip.ps
@@ -89,7 +89,9 @@ def
 % clip path can arrive in the opposite device-space winding (e.g. after
 % the y-flip), which would keep the exterior and clip everything away.
 % Reverse such a polygon so its winding always matches.
-/normclipwind { % poly  .  poly'
+% doubled signed area of a closed polygon (first point repeated at the
+% end); positive when wound counter-clockwise in device space
+/polyarea2 { % poly  .  a2
     8 dict begin
     /poly exch def
     /a2 0.0 def
@@ -99,12 +101,17 @@ def
         poly i 1 add get aload pop /yj exch def /xj exch def
         /a2 a2 xi yj mul xj yi mul sub add def
     } for
-    a2 0 lt {
-        [ poly length 1 sub -1 0 { poly exch get } for ]
-    }{
-        poly
-    } ifelse
+    a2
     end
+} bind def
+
+/normclipwind { % poly  .  poly'
+    dup polyarea2 0 lt {
+        4 dict begin
+        /poly exch def
+        [ poly length 1 sub -1 0 { poly exch get } for ]
+        end
+    } if
 } bind def
 
 % polygon [A B C]  .  new-polygon
@@ -172,7 +179,7 @@ def
 % convert polygon array back to path structure
 /doclip {
 	%DICT
-	10 dict
+	20 dict
 	begin
 
     %/isclosed 
@@ -227,11 +234,21 @@ def
         %hook
     } if
 
+    % A clip path may carry several subpaths: the first is the clip
+    % window, and any later subpath wound the opposite way is a hole
+    % cut out of it (the nonzero-rule idiom for clipping around a
+    % reserved area). Later subpaths with the window's winding are
+    % treated as further windows to intersect, as before.
+    /wsign 0 def
     CR { % one clipping polygon
-        %dup dup length 2 sub get % polygon final-point
 	dup length 0 eq {
 	    pop
 	}{
+	    dup polyarea2 0 lt { -1 }{ 1 } ifelse /psign exch def
+	    wsign 0 eq { /wsign psign def } if
+	    psign wsign eq {
+
+	    % intersect the subject polygons with the (convex) window
 	    normclipwind
 	    dup 0 get
 	    /U exch def
@@ -251,6 +268,36 @@ def
 		/U V def
 	    } forall
 
+	    }{
+
+	    % subtract the (convex) hole: the difference decomposes into
+	    % one piece per hole edge - the part beyond that edge,
+	    % limited by the edges before it
+	    normclipwind
+	    /HP exch def
+	    /HL [
+		HP 0 get /U exch def
+		HP 1 HP length 1 sub getinterval {
+		    /V exch def
+		    [ U aload pop V aload pop p2abc ]
+		    /U V def
+		} forall
+	    ] def
+	    /PA [
+		PA {
+		    /SP exch def
+		    0 1 HL length 1 sub {
+			/hi exch def
+			/piece SP [ HL hi get { neg } forall ] hodgman-sutherland def
+			0 1 hi 1 sub {
+			    /piece piece 3 -1 roll HL exch get hodgman-sutherland def
+			} for
+			piece length 3 gt { piece } if
+		    } for
+		} forall
+	    ] def
+
+	    } ifelse
 	} ifelse
     } forall
     newpath

--- a/data/clip.ps
+++ b/data/clip.ps
@@ -83,116 +83,81 @@ def
     add add
 } bind def
 
+% hodgman-sutherland keeps the half-plane to the left of each directed
+% clip edge, so a clip polygon's interior must lie to the left of its
+% edges: a positive signed area, the winding initclip produces. A user
+% clip path can arrive in the opposite device-space winding (e.g. after
+% the y-flip), which would keep the exterior and clip everything away.
+% Reverse such a polygon so its winding always matches.
+/normclipwind { % poly  .  poly'
+    8 dict begin
+    /poly exch def
+    /a2 0.0 def
+    0 1 poly length 2 sub {
+        /i exch def
+        poly i get aload pop /yi exch def /xi exch def
+        poly i 1 add get aload pop /yj exch def /xj exch def
+        /a2 a2 xi yj mul xj yi mul sub add def
+    } for
+    a2 0 lt {
+        [ poly length 1 sub -1 0 { poly exch get } for ]
+    }{
+        poly
+    } ifelse
+    end
+} bind def
+
 % polygon [A B C]  .  new-polygon
+% Canonical Sutherland-Hodgman: clip the closed polygon (points array,
+% first point repeated at the end) against the half-plane where the clip
+% line evaluates <= 0. For each edge P->Q emit Q when it lies inside, and
+% emit the edge's crossing point wherever the edge enters or leaves the
+% half-plane. Correct for any convex clip window and any edge orientation.
 /hodgman-sutherland {
 	DICT
-	%10 dict
 	begin
     /f exch def
     /p exch def
-    /n p length 1 sub def
-    /DEBUGCLIP where { pop
-        (n=)print n =
-    } if
-    n 0 gt { % else nothing to do.
-
-    % P = p[n-1] to start !!No. our poly has a duplicate point at the end
-    %/P p n 1 sub get def
-    %/d P length 1 sub def
-    /P p 0 get def
-    /fP P aload pop f evaluate def
-    /starting true def
-    /first null def
-    [
-        p 1 1 index length 1 sub getinterval {
-            /Q exch def
-            /fQ Q aload pop f evaluate def
-            /DEBUGCLIP where { pop
-                (P=)print P ==
-                (Q=)print Q ==
-                (fP=)print fP ==
-                (fQ=)print fQ ==
-            } if
-            fP 0 le {
-                counttomark 0 eq {
-                    P
-                    /DEBUGCLIP where { pop
-                        (P)=
-                    } if
-                } if
+    /n p length 1 sub def   % edge count (p carries a duplicated closing point)
+    /DEBUGCLIP where { pop (n=)print n = } if
+    n 0 gt {
+        /out [
+            0 1 n 1 sub {
+                /i exch def
+                /P p i get def
+                /Q p i 1 add get def
+                /fP P aload pop f evaluate def
+                /fQ Q aload pop f evaluate def
                 fQ 0 le {
-                    Q
-                    /DEBUGCLIP where { pop
-                        (Q)=
-                    } if
-                }{
-                    fP 0 lt {
+                    fP 0 le not {          % P outside, Q inside: entering crossing
                         /QP fQ fP sub def
                         [
                             fQ P 0 get mul fP Q 0 get mul sub QP div
                             fQ P 1 get mul fP Q 1 get mul sub QP div
                         ]
-                        %dup /P exch def
-                        %/dup /Q exch def
-                        %/fQ -1 def
-                        %dup aload pop f evaluate /fQ exch def
-                        /DEBUGCLIP where { pop
-                            (I)=
-                        } if
+                    } if
+                    Q                      % Q inside
+                }{
+                    fP 0 le {              % P inside, Q outside: leaving crossing
+                        /QP fQ fP sub def
+                        [
+                            fQ P 0 get mul fP Q 0 get mul sub QP div
+                            fQ P 1 get mul fP Q 1 get mul sub QP div
+                        ]
                     } if
                 } ifelse
-            }{
-                fQ 0 le {
-                    fQ 0 lt {
-                        /QP fQ fP sub def
-                        [
-                            fQ P 0 get mul fP Q 0 get mul sub QP div
-                            fQ P 1 get mul fP Q 1 get mul sub QP div
-                        ]
-                        %dup /P exch def
-                        %/dup /Q exch def
-                        %/fQ -1 def
-                        %dup aload pop f evaluate /fQ exch def
-                        starting {
-                            /first 1 index
-                                %pstack()=
-                                2 array copy
-                                def  % first point was clipped
-                        } if
-                        /DEBUGCLIP where { pop
-                            (I)=
-                        } if
-                    } if
-                    Q
-                    /DEBUGCLIP where { pop
-                        (Q)=
-                    } if
-                } if
-            } ifelse
-            /P Q def
-            /fP fQ def
-            /starting false def
-        } forall
-        first type /nulltype ne { % if first point was clipped and path was closed, add final intersection
-            fQ 0 gt {
-                Q aload pop  % Qx Qy
-                p 0 get aload pop  % Qx Qy Px Py
-                3 2 roll eq 3 1 roll eq and { % Qx==Px&&Qy==Py
-                    first %2 array copy
-                } if
-            } if
-        } if
-    ]
-    /DEBUGCLIP where { pop
-        dup ==
-    } if
-
-    }{ % n==0
+            } for
+        ] def
+        out length 0 gt {                  % re-close: repeat the first vertex
+            [ out aload pop out 0 get ]
+        }{
+            out
+        } ifelse
+    }{
         p
     } ifelse
-
 end }
-dup 0 10 dict put
+dup 0 16 dict put
 bind
 def
 
@@ -267,7 +232,7 @@ def
 	dup length 0 eq {
 	    pop
 	}{
-	    
+	    normclipwind
 	    dup 0 get
 	    /U exch def
 	    1 1 index length 1 sub getinterval

--- a/data/clip.ps
+++ b/data/clip.ps
@@ -175,6 +175,23 @@ bind
 def
 
 
+% A subpath split off at a closepath enters through the bridge the
+% path walked from the closing point: its leading edge doubles its
+% trailing edge. Peel such pairs until the polygon walks only its own
+% boundary; what remains classifies as a window or hole by winding.
+/despike { % poly  .  poly'
+    2 dict begin
+    /p exch def
+    { % loop
+        p length 4 lt { exit } if
+        p 1 get aload pop p p length 2 sub get aload pop
+        exch 4 -1 roll eq 3 1 roll eq and not { exit } if
+        /p p 1 p length 2 sub getinterval def
+    } loop
+    p
+    end
+} bind def
+
 %clip the current path by the clipregion
 % convert the path to an array of polygons (arrays of points)
 % convert clipregion to array of polygons
@@ -213,6 +230,11 @@ def
         ]  % /PA mark [...] [...] [...] 
     ] def
 
+    % A closepath ends a clip subpath, but need not be followed by a
+    % moveto: a segment operator may continue from the closing point
+    % (the straight line arc appends is the common case, building a
+    % ring as one keyhole path). Split polygons at the close as well
+    % as at movetos, so each ring boundary classifies separately.
     /CR                         % Clip Region   clippath array
     clippath [
         %{ 2 array astore [ exch } { 2 array astore } {} {]} .devpathforall
@@ -226,7 +248,7 @@ def
         }
         { 2 array astore }
         {}
-        { counttomark 1 sub index }
+        { counttomark 1 sub index ] [ }
         .devpathforall
         ]
     ]
@@ -247,6 +269,7 @@ def
     % treated as further windows to intersect, as before.
     /wsign 0 def
     CR { % one clipping polygon
+	despike
 	% fewer than three points bound no area (e.g. the bare pen
 	% moveto charpath leaves after its outlines)
 	dup length 3 lt {

--- a/data/clip.ps
+++ b/data/clip.ps
@@ -54,10 +54,16 @@ def
 
 
 /clip {
+    % the clip machinery consumes line segments, so the region is cut
+    % from a flattened working copy; the caller's path is kept aside
+    % and put back, undisturbed by flattening or the intersection
+    graphicsdict /currgstate get /currpath get
+    1 dict deepcopy
+    flattenpath
     doclip
     graphicsdict /currgstate get
     dup /currpath get /clipregion exch put
-    %newpath %NO! clip does not disturb the current path.
+    graphicsdict /currgstate get /currpath 3 -1 roll put
 } def
 
 
@@ -241,7 +247,9 @@ def
     % treated as further windows to intersect, as before.
     /wsign 0 def
     CR { % one clipping polygon
-	dup length 0 eq {
+	% fewer than three points bound no area (e.g. the bare pen
+	% moveto charpath leaves after its outlines)
+	dup length 3 lt {
 	    pop
 	}{
 	    dup polyarea2 0 lt { -1 }{ 1 } ifelse /psign exch def
@@ -255,15 +263,20 @@ def
 	    1 1 index length 1 sub getinterval
 	    {
 		/V exch def
-		[ U aload pop V aload pop p2abc ]  % clip-line
-		/CL exch def
-		/DEBUGCLIP where { pop
-		    CL ==
-		} if
+		U 0 get V 0 get sub abs U 1 get V 1 get sub abs add 0.001 lt {
+		    % a degenerate edge (a contour closing on its own start,
+		    % exactly or within float noise) has no usable half-plane
+		}{
+		    [ U aload pop V aload pop p2abc ]  % clip-line
+		    /CL exch def
+		    /DEBUGCLIP where { pop
+			CL ==
+		    } if
 
-		/PA [ PA { % one subject polygon
-		    CL hodgman-sutherland
-		} forall ] def
+		    /PA [ PA { % one subject polygon
+			CL hodgman-sutherland
+		    } forall ] def
+		} ifelse
 
 		/U V def
 	    } forall
@@ -279,7 +292,9 @@ def
 		HP 0 get /U exch def
 		HP 1 HP length 1 sub getinterval {
 		    /V exch def
-		    [ U aload pop V aload pop p2abc ]
+		    U 0 get V 0 get sub abs U 1 get V 1 get sub abs add 0.001 ge {
+			[ U aload pop V aload pop p2abc ]
+		    } if
 		    /U V def
 		} forall
 	    ] def

--- a/data/color.ps
+++ b/data/color.ps
@@ -82,7 +82,7 @@
             2 index add 1 .min sub % k 1-min(1,c+k)
             1 graphicsdict /currgstate get /colorcomp2 get % k R 1 m
             3 index add 1 .min sub % k R 1-min(1,m+k)
-            1 graphicsdict /currgstate get /colorcomp2 get % k R G 1 y
+            1 graphicsdict /currgstate get /colorcomp3 get % k R G 1 y
             5 4 roll add 1 .min sub % R G 1-min(1,y+k)
         } bind
     >>

--- a/data/color.ps
+++ b/data/color.ps
@@ -88,17 +88,25 @@
     >>
     /DeviceCMYK <<
         /DeviceGray {
-            O
+            0
             0
             0
             1 graphicsdict /currgstate get /colorcomp1 get sub
         } bind
         /DeviceRGB {
-            1 graphicsdict /currgstate get /colorcomp1 get sub % c
-            1 graphicsdict /currgstate get /colorcomp2 get sub % c m
-            1 graphicsdict /currgstate get /colorcomp3 get sub % c m y
-            3 copy .min .min % c m y k
-            %FIXME invoke undercolorremoval and blackgeneration
+            % full black generation and undercolor removal: the common
+            % component moves entirely into the black channel, so black
+            % separates as pure K rather than four inks
+            1 graphicsdict /currgstate get /colorcomp1 get sub
+            1 graphicsdict /currgstate get /colorcomp2 get sub .min
+            1 graphicsdict /currgstate get /colorcomp3 get sub .min  % k
+            dup dup dup                                              % k k k k
+            1 graphicsdict /currgstate get /colorcomp1 get sub exch sub % k k k c'
+            4 1 roll                                                 % c' k k k
+            1 graphicsdict /currgstate get /colorcomp2 get sub exch sub % c' k k m'
+            3 1 roll                                                 % c' m' k k
+            1 graphicsdict /currgstate get /colorcomp3 get sub exch sub % c' m' k y'
+            exch                                                     % c' m' y' k
         } bind
         /DeviceCMYK {
             graphicsdict /currgstate get /colorcomp1 get

--- a/data/color.ps
+++ b/data/color.ps
@@ -38,6 +38,12 @@
         %        y (otherwise)
     2 copy gt{exch}if pop
 } bind def
+% component  .c01  real in [0,1]
+% a colour component is clamped to the unit range (PLRM: values outside
+% 0 to 1 are adjusted to the nearest valid value)
+/.c01 {
+    cvr dup 0.0 lt { pop 0.0 } if dup 1.0 gt { pop 1.0 } if
+} bind def
 
 /ColorConversion << % <</dest <</source {source-to-dest conversion}>> >>
     /DeviceGray <<
@@ -119,7 +125,7 @@
 
 /setgray {
     graphicsdict /currgstate get /colorspace /DeviceGray put
-    graphicsdict /currgstate get exch /colorcomp1 exch put
+    graphicsdict /currgstate get exch .c01 /colorcomp1 exch put
 } bind def
 
 /currentgray {
@@ -130,9 +136,9 @@
 
 /setrgbcolor {
     graphicsdict /currgstate get /colorspace /DeviceRGB put
-    graphicsdict /currgstate get exch /colorcomp3 exch put
-    graphicsdict /currgstate get exch /colorcomp2 exch put
-    graphicsdict /currgstate get exch /colorcomp1 exch put
+    graphicsdict /currgstate get exch .c01 /colorcomp3 exch put
+    graphicsdict /currgstate get exch .c01 /colorcomp2 exch put
+    graphicsdict /currgstate get exch .c01 /colorcomp1 exch put
 } bind def
 
 /currentrgbcolor {
@@ -144,11 +150,14 @@
 % hue saturation brightness  sethsbcolor  -
 % the components are recorded in RGB, converted with the usual
 % hexcone model (hue scaled to a sector 0-5; the sector's fractional
-% part blends between the derived p, q and t values)
+% part blends between the derived p, q and t values). Each component is
+% clamped to [0,1] first, as the reference interpreters clamp hue rather
+% than wrap it.
 /sethsbcolor {
+    3 { .c01 3 1 roll } repeat
     7 dict begin
     {/b /s /h}{exch def}forall
-    /h h h truncate sub 6 mul def       % wrap hue, scale to sector 0-5
+    /h h h truncate sub 6 mul def       % scale hue to sector 0-5 (1 maps to 0)
     /i h truncate cvi def
     /f h i sub def
     /p b 1 s sub mul def
@@ -171,7 +180,7 @@
     /v r g 2 copy lt {exch} if pop b 2 copy lt {exch} if pop def
     /d v r g 2 copy gt {exch} if pop b 2 copy gt {exch} if pop sub def
     d 0 eq {
-        0 0 v
+        0.0 0.0 v
     }{
         v r eq { g b sub d div 6 add
         }{ v g eq { b r sub d div 2 add
@@ -185,10 +194,10 @@
 
 /setcmykcolor {
     graphicsdict /currgstate get /colorspace /DeviceCMYK put
-    graphicsdict /currgstate get exch /colorcomp4 exch put
-    graphicsdict /currgstate get exch /colorcomp3 exch put
-    graphicsdict /currgstate get exch /colorcomp2 exch put
-    graphicsdict /currgstate get exch /colorcomp1 exch put
+    graphicsdict /currgstate get exch .c01 /colorcomp4 exch put
+    graphicsdict /currgstate get exch .c01 /colorcomp3 exch put
+    graphicsdict /currgstate get exch .c01 /colorcomp2 exch put
+    graphicsdict /currgstate get exch .c01 /colorcomp1 exch put
 } bind def
 
 /currentcmykcolor {

--- a/data/color.ps
+++ b/data/color.ps
@@ -141,17 +141,46 @@
         get exec
 } bind def
 
+% hue saturation brightness  sethsbcolor  -
+% the components are recorded in RGB, converted with the usual
+% hexcone model (hue scaled to a sector 0-5; the sector's fractional
+% part blends between the derived p, q and t values)
 /sethsbcolor {
-    graphicsdict /currgstate get /colorspace /DeviceRGB put
-    graphicsdict /currgstate get exch /colorcomp3 exch put
-    graphicsdict /currgstate get exch /colorcomp2 exch put
-    graphicsdict /currgstate get exch /colorcomp1 exch put
+    7 dict begin
+    {/b /s /h}{exch def}forall
+    /h h h truncate sub 6 mul def       % wrap hue, scale to sector 0-5
+    /i h truncate cvi def
+    /f h i sub def
+    /p b 1 s sub mul def
+    /q b 1 s f mul sub mul def
+    /t b 1 s 1 f sub mul sub mul def
+    i 0 eq { b t p }{
+    i 1 eq { q b p }{
+    i 2 eq { p b t }{
+    i 3 eq { p q b }{
+    i 4 eq { t p b }{
+             b p q } ifelse } ifelse } ifelse } ifelse } ifelse
+    end
+    setrgbcolor
 } bind def
 
 /currenthsbcolor {
-    ColorConversion /DeviceRGB get
-        graphicsdict /currgstate get /colorspace get
-        get exec
+    currentrgbcolor
+    3 dict begin
+    {/b /g /r}{exch def}forall
+    /v r g 2 copy lt {exch} if pop b 2 copy lt {exch} if pop def
+    /d v r g 2 copy gt {exch} if pop b 2 copy gt {exch} if pop sub def
+    d 0 eq {
+        0 0 v
+    }{
+        v r eq { g b sub d div 6 add
+        }{ v g eq { b r sub d div 2 add
+        }{ r g sub d div 4 add } ifelse } ifelse
+        6 div dup truncate sub          % hue
+        d v div                         % saturation
+        v                               % brightness
+    } ifelse
+    end
 } bind def
 
 /setcmykcolor {

--- a/data/err.ps
+++ b/data/err.ps
@@ -65,10 +65,24 @@ errordict begin
                 (; OffendingCommand: ) print
                 /command load //=print exec
                 (]%%\n) print
-                (Stack:\n) print
-                ostack { == } forall
-                (ExecStack:\n) print
-                estack { == } forall
+                % a program may raise an error by setting newerror,
+                % errorname and errorinfo in $error directly and then
+                % executing stop, without passing through .error: the
+                % stack snapshots are absent in that case
+                currentdict /errorinfo known {
+                    errorinfo null ne {
+                        (Additional information: ) print
+                        errorinfo ==
+                    } if
+                } if
+                currentdict /ostack known {
+                    (Stack:\n) print
+                    ostack { == } forall
+                } if
+                currentdict /estack known {
+                    (ExecStack:\n) print
+                    estack { == } forall
+                } if
                 flush
             } if
         end

--- a/data/err.ps
+++ b/data/err.ps
@@ -87,7 +87,7 @@ errordict begin
                 errorname //=print exec
                 (; OffendingCommand: ) print
                 /command load //=print exec
-                (]%%\n) print
+                ( ]%%\n) print
                 % a program may raise an error by setting newerror,
                 % errorname and errorinfo in $error directly and then
                 % executing stop, without passing through .error: the

--- a/data/err.ps
+++ b/data/err.ps
@@ -10,13 +10,21 @@ currentglobal
 false setglobal
 userdict begin
 
-/$error 13 dict def
+/$error 16 dict def
 $error begin
     /ostackarray null def
     /newerror false def
     /command null def
     /errorname null def
     /initializing true def
+    % the standard entries the reference interpreters carry: whether
+    % an error records the stacks into $error (settable to skip the
+    % snapshot), and the extra context certain errors leave behind
+    /recordstacks true def
+    /errorinfo null def
+    /ostack null def
+    /estack null def
+    /dstack null def
 end
 /QUIET where { pop }{ ($error installed...)print } ifelse
 
@@ -25,7 +33,8 @@ end
     //$error exch /errorname exch put
     //$error exch /command exch put
     //$error /newerror true put
-    //$error /errorname get /VMerror ne {
+    //$error /errorname get /VMerror ne
+    //$error /recordstacks get and {
         //$error /ostackarray get null eq {
             //$error /estackarray 600 array put
             //$error /ostackarray 1000 array put

--- a/data/err.ps
+++ b/data/err.ps
@@ -31,12 +31,26 @@ end
             //$error /ostackarray 1000 array put
             //$error /dstackarray 50 array put
         } if
-        count
+        % The snapshots must never raise inside the error machinery itself:
+        % clamp each stack to its snapshot array's capacity. A clamped
+        % operand snapshot keeps the topmost entries only; the deeper
+        % entries stay on the stack and survive the aload round-trip.
+        count dup //$error /ostackarray get length gt {
+            pop //$error /ostackarray get length
+        } if
         //$error /ostackarray get exch 0 exch getinterval astore
         //$error exch /ostack exch put
-        //$error /dstack //$error /dstackarray get dictstack put
-        //$error /estack //$error /estackarray get execstack
-        dup length 2 sub 0 exch getinterval put % trim 1:{ //$err... 2:{ //$err... execstack
+        countdictstack //$error /dstackarray get length le {
+            //$error /dstack //$error /dstackarray get dictstack put
+        } {
+            //$error /dstack null put
+        } ifelse
+        countexecstack //$error /estackarray get length le {
+            //$error /estack //$error /estackarray get execstack
+            dup length 2 sub 0 exch getinterval put % trim 1:{ //$err... 2:{ //$err... execstack
+        } {
+            //$error /estack null put % too deep to snapshot
+        } ifelse
         //$error /ostack get aload pop
     } if
     //$error /initializing get {

--- a/data/graphics.ps
+++ b/data/graphics.ps
@@ -33,6 +33,28 @@ userdict begin
 graphicsdict /currgstate get /device DEVICE put
 /DEVICE { graphicsdict /currgstate get /device get } def
 
+% The graphics machinery is implemented in PostScript and runs in the
+% middle of user programs, whose dictionaries are then on the dict
+% stack: an unbound operator name in these procedures can be captured
+% by an unrelated definition in a user dictionary (a variable named
+% /type or /copy, for example). Bind every procedure - including the
+% methods of device class dictionaries and the procedures the boot
+% files left in systemdict - so operator references are resolved now.
+% Names that resolve to procedures are left dynamic, so wrappers still
+% dispatch through the dict stack.
+[ currentdict systemdict ] {
+    {
+        exch pop
+        dup type /dicttype eq {
+            { exch pop
+              dup type /arraytype eq 1 index xcheck and { bind } if pop
+            } forall
+        }{
+            dup type /arraytype eq 1 index xcheck and { bind } if pop
+        } ifelse
+    } forall
+} forall
+
 end %userdict
 
 /QUIET where { pop }{ (eof graphics.ps\n)print } ifelse

--- a/data/gstate.ps
+++ b/data/gstate.ps
@@ -18,8 +18,8 @@
     /flat 1
     /linewidth 1
     /linecap 0
-    /linejoin 2
-    /miterlimit 0.0
+    /linejoin 0
+    /miterlimit 10.0
     /overprint false
     /dasharray []
     /dashoffset 0

--- a/data/gstate.ps
+++ b/data/gstate.ps
@@ -97,7 +97,7 @@
 /gsave {
 graphicsdict begin
     /gptr gptr 1 add def
-    gptr gstackarray length ge { error } if
+    gptr gstackarray length ge { /gsave cvx /limitcheck signalerror } if
     gstackarray gptr gstate currentgstate put % push copy on stack
     currgstate /currpath 2 copy get 1 dict deepcopy put % make a new working copy of path
 end

--- a/data/gstate.ps
+++ b/data/gstate.ps
@@ -220,7 +220,14 @@ end
 } def
 
 % array offset  setdash  -
+% a non-empty dash array must hold no negative element and not be all zero
 /setdash {
+    1 index dup length 0 gt {
+        false exch
+        { dup 0 lt { pop pop /setdash cvx /rangecheck signalerror } if
+          0 gt { pop true } if } forall
+        not { /setdash cvx /rangecheck signalerror } if
+    } { pop } ifelse
     graphicsdict /currgstate get exch cvr /dashoffset exch put
     graphicsdict /currgstate get exch /dasharray exch put
 } def

--- a/data/gstate.ps
+++ b/data/gstate.ps
@@ -64,10 +64,19 @@
             1 index % key val key
             currentdict 1 index known { % key val key  (key known in currentdict)
                 currentdict exch get % key val dict2-val
-                2 copy length exch length exch % key val dict2-val n d2-n
-                le {
-                    copy % key dict2-val
-                    pop pop
+                % the existing value only offers reusable storage if it
+                % is itself an array (a colour space entry may hold a
+                % name in one state and an array in another)
+                dup type /arraytype eq {
+                    2 copy length exch length exch % key val dict2-val n d2-n
+                    le {
+                        copy % key dict2-val
+                        pop pop
+                    }{
+                        pop dup length array
+                        copy
+                        def
+                    } ifelse
                 }{
                     pop dup length array
                     copy

--- a/data/gstate.ps
+++ b/data/gstate.ps
@@ -70,8 +70,12 @@
                 dup type /arraytype eq {
                     2 copy length exch length exch % key val dict2-val n d2-n
                     le {
-                        copy % key dict2-val
-                        pop pop
+                        % reuse the storage, but the entry must take the
+                        % subarray copy returns: a shorter value left
+                        % behind the old full-length array (a dash set
+                        % inside gsave survived its grestore)
+                        copy % key dict2-val'
+                        def
                     }{
                         pop dup length array
                         copy

--- a/data/gstate.ps
+++ b/data/gstate.ps
@@ -208,7 +208,9 @@ end
 % int  setlinecap  -
 % set shape of the ends for stroke (0=butt, 1=round, 2=square)
 /setlinecap {
-    graphicsdict /currgstate get exch /linecap exch put
+    dup 0 lt 1 index 2 gt or
+    { pop /setlinecap cvx /rangecheck signalerror }
+    { graphicsdict /currgstate get exch /linecap exch put } ifelse
 } def
 
 % -  currentlinecap  int
@@ -232,7 +234,9 @@ end
 % int  setlinejoin  -
 % set shape of corners for stroke (0=miter, 1=round, 2=bevel)
 /setlinejoin {
-    graphicsdict /currgstate get exch /linejoin exch put
+    dup 0 lt 1 index 2 gt or
+    { pop /setlinejoin cvx /rangecheck signalerror }
+    { graphicsdict /currgstate get exch /linejoin exch put } ifelse
 } def
 
 % -  currentlinejoin  int
@@ -243,7 +247,9 @@ end
 
 % num  setmiterlimit  -
 /setmiterlimit {
-    graphicsdict /currgstate get exch /miterlimit exch put
+    dup 1 lt
+    { pop /setmiterlimit cvx /rangecheck signalerror }
+    { graphicsdict /currgstate get exch /miterlimit exch put } ifelse
 } def
 
 % -  currentmiterlimit  num

--- a/data/gstate.ps
+++ b/data/gstate.ps
@@ -5,24 +5,24 @@
 % are newly-allocated arrays.
 /gstatetemplate <<
     /colorspace /DeviceGray
-    /colorcomp1 0
-    /colorcomp2 0
-    /colorcomp3 0
-    /colorcomp4 0
+    /colorcomp1 0.0
+    /colorcomp2 0.0
+    /colorcomp3 0.0
+    /colorcomp4 0.0
     /transfer {}
     %/currmatrix DEVICE /defaultmatrix get matrix copy
     %/currmatrix [ 1 0 0 1 0 0 ]
     %/scratchmatrix [ 1 0 0 1 0 0 ] % ??
     /currpath 1 dict
     /clipregion 1 dict
-    /flat 1
-    /linewidth 1
+    /flat 1.0
+    /linewidth 1.0
     /linecap 0
     /linejoin 0
     /miterlimit 10.0
     /overprint false
     /dasharray []
-    /dashoffset 0
+    /dashoffset 0.0
     /currfont 1 dict
     /device DEVICE
 >> def
@@ -196,7 +196,7 @@ end
 % num  setlinewidth  -
 % set line width
 /setlinewidth {
-    graphicsdict /currgstate get exch /linewidth exch put
+    graphicsdict /currgstate get exch cvr /linewidth exch put
 } def
 
 % -  currentlinewidth  num
@@ -221,7 +221,7 @@ end
 
 % array offset  setdash  -
 /setdash {
-    graphicsdict /currgstate get exch /dashoffset exch put
+    graphicsdict /currgstate get exch cvr /dashoffset exch put
     graphicsdict /currgstate get exch /dasharray exch put
 } def
 
@@ -249,7 +249,7 @@ end
 /setmiterlimit {
     dup 1 lt
     { pop /setmiterlimit cvx /rangecheck signalerror }
-    { graphicsdict /currgstate get exch /miterlimit exch put } ifelse
+    { graphicsdict /currgstate get exch cvr /miterlimit exch put } ifelse
 } def
 
 % -  currentmiterlimit  num
@@ -273,7 +273,7 @@ end
 /setflat {
     /CONSTRAINFLATNESS where{
         pop dup 100 gt{pop 100}if dup .2 lt{pop .2}if } if
-    graphicsdict /currgstate get exch /flat exch put
+    graphicsdict /currgstate get exch cvr /flat exch put
 } def
 
 /currentflat {

--- a/data/init.ps
+++ b/data/init.ps
@@ -16,6 +16,18 @@ true setglobal   % systemdict is global, so these allocations must be global
     /product (Xpost)
 >> def
 
+% the job server's dictionary. exitserver ends the encapsulated job,
+% announces that permanent state may change, and execution continues
+% with the definitions made so far outliving the job -- the idiom
+% every driver prolog uses. xpost runs jobs unencapsulated, so
+% announcing and unwinding the begun dictionary is the whole of it.
+/serverdict 2 dict def
+serverdict /exitserver {
+    pop
+    (%%[ exitserver: permanent state may be changed ]%%\n) print flush
+    currentdict serverdict eq { end } if
+} put
+
 /strcat {
     2 copy
     length exch length exch 1 index add % a b an bn+an

--- a/data/init.ps
+++ b/data/init.ps
@@ -171,8 +171,10 @@ userdict begin
     %traceon
     //==dict begin
         /cp 0 def
-        typeprint
-    end
+        { typeprint } stopped
+    end            % pop ==dict whether typeprint succeeded or errored,
+    { stop } if    % so an error inside == does not strand it on the
+                   % dict stack; re-raise once the dict stack is clean
 } end def % remove ==dict, installing == in userdict
 /== { ==only (\n) print } def
 /pstack { count dup 1 add copy //== repeat pop } def

--- a/data/init.ps
+++ b/data/init.ps
@@ -259,6 +259,18 @@ end
     pop //quit % the operator
 } def
 
+% report a top-level job error the way a job server does: the standard
+% error line (through handleerror), then -- only when an error really
+% occurred, not on a normal quit -- the notice that the rest of the job
+% is flushed to end of file. An interactive executive keeps going, so it
+% reports without this line.
+/.handlejoberror {
+    $error /newerror get
+    handleerror
+    { (%%[ Flushing: rest of job \(to end-of-file\) will be ignored ]%%\n)
+      print flush } if
+} def
+
 % execute postscript program from stdin, and handle errors,
 % but do not assume an interactive session
 /startstdin {
@@ -271,7 +283,7 @@ end
     {
         (%stdin) run
     } stopped {
-        handleerror
+        .handlejoberror
     } if
     quit
 } def
@@ -289,7 +301,7 @@ end
         inputfilename (r) file cvx exec
         executive
     } stopped {
-        handleerror
+        .handlejoberror
     } if
     quit
 } def
@@ -309,7 +321,7 @@ end
     {
         inputfile cvx exec
     } stopped {
-        handleerror
+        .handlejoberror
     } if
     quit
 } def

--- a/data/init.ps
+++ b/data/init.ps
@@ -575,9 +575,12 @@ end % userdict
     lineto
 } def
 
-/rectfill { rect fill } def
-/rectstroke { rect stroke } def
-/rectclip { rect clip } def
+% the painting pair works on its own path and leaves the caller's
+% untouched; rectclip clips by the rectangles alone and clears the
+% path, as the language specifies
+/rectfill { gsave newpath rect fill grestore } def
+/rectstroke { gsave newpath rect stroke grestore } def
+/rectclip { newpath rect clip newpath } def
 
 /runtest {
     DATA_DIR (/test.ps) strcat run

--- a/data/init.ps
+++ b/data/init.ps
@@ -120,7 +120,6 @@ userdict begin
 
     /cvsprint {
         =string cvs tprint
-        ( ) tprint
     } def
     /tprint {
         dup length cp add rmargin gt {
@@ -134,11 +133,13 @@ userdict begin
 
     /arraytype {
         dup rcheck {
-            dup xcheck {
-                ({ ) tprint { typeprint } forall (} ) tprint
-            }{
-                ([ ) tprint { typeprint } forall (] ) tprint
-            } ifelse
+            1 dict begin
+            /first true def
+            dup xcheck /isproc exch def
+            isproc { ({) }{ ([) } ifelse tprint
+            { first { /first false def }{ ( ) tprint } ifelse typeprint } forall
+            isproc { (}) }{ (]) } ifelse tprint
+            end
         }{ pop (-array-) tprint } ifelse
     } def
     { cvsprint }
@@ -147,12 +148,12 @@ userdict begin
     /realtype exch def
 
     /invalidtype { pop (@INVALID@) tprint } def
-    /nulltype { pop (null ) tprint } def
-    /dicttype { pop (-dict- ) tprint } def
-    /filetype { pop (-file- ) tprint } def
-    /marktype { pop (-mark- ) tprint } def
-    /fonttype { pop (-font- ) tprint } def
-    /contexttype { pop (-context- ) tprint } def
+    /nulltype { pop (null) tprint } def
+    /dicttype { pop (-dict-) tprint } def
+    /filetype { pop (-file-) tprint } def
+    /marktype { pop (-mark-) tprint } def
+    /fonttype { pop (-font-) tprint } def
+    /contexttype { pop (-context-) tprint } def
 
     /nametype {
         dup xcheck not {
@@ -168,12 +169,40 @@ userdict begin
     } def
 
     /savetype {
-        pop (-savelevel- ) tprint
+        pop (-savelevel-) tprint
+    } def
+
+    % re-readable string escaping for ==: a byte becomes \\ \( \) for
+    % those three, a named escape for the five control characters that
+    % have one, its own character when printable, and \ddd octal
+    % otherwise -- so the output scans back to the same string
+    /.es1 1 string def
+    /.es3 3 string def
+    /.escbyte { % byte  .  -
+        dup 92 eq { pop (\\\\) print }{
+        dup 40 eq { pop (\\\() print }{
+        dup 41 eq { pop (\\\)) print }{
+        dup 10 eq { pop (\\n) print }{
+        dup 13 eq { pop (\\r) print }{
+        dup  9 eq { pop (\\t) print }{
+        dup  8 eq { pop (\\b) print }{
+        dup 12 eq { pop (\\f) print }{
+        dup 32 ge 1 index 127 lt and {
+            .es1 exch 0 exch put .es1 print
+        }{
+            (\\) print
+            dup 64 idiv 48 add .es3 exch 0 exch put
+            dup  8 idiv 8 mod 48 add .es3 exch 1 exch put
+            8 mod 48 add .es3 exch 2 exch put
+            .es3 print
+        } ifelse } ifelse } ifelse } ifelse } ifelse } ifelse } ifelse } ifelse } ifelse
     } def
 
     /stringtype {
         dup rcheck {
-            (\() tprint tprint (\)) tprint
+            (\() tprint
+            { .escbyte } forall
+            (\)) print
         }{
             pop (-string- ) tprint
         } ifelse

--- a/data/init.ps
+++ b/data/init.ps
@@ -335,18 +335,41 @@ end
     flush
 } def
 
-/setdevparams {
-} def
-/currentdevparams {
+% User, system, and device parameters. The current* operators return a fresh
+% dictionary of the present values; the set* operators apply the parameters they
+% recognise from the supplied dictionary and ignore the rest. The stack limits
+% mirror the interpreter's fixed capacities (XPOST_{OPER,DICT,EXEC}_STACK_LIMIT
+% in xpost_interpreter.c) and cannot be changed.
+currentglobal true setglobal
+/.uparams << /VMReclaim 0 /VMThreshold 0 >> def
+setglobal
+
+/setdevparams { pop pop } def
+/currentdevparams { pop 0 dict } def
+
+/currentuserparams {
+    << /MaxOpStack 1000000 /MaxDictStack 5000 /MaxExecStack 1000000
+       /VMReclaim .uparams /VMReclaim get
+       /VMThreshold .uparams /VMThreshold get >>
 } def
 /setuserparams {
+    dup /VMReclaim known {
+        dup /VMReclaim get
+        dup .uparams /VMReclaim 3 -1 roll put
+        vmreclaim
+    } if
+    dup /VMThreshold known {
+        dup /VMThreshold get
+        dup .uparams /VMThreshold 3 -1 roll put
+        setvmthreshold
+    } if
+    pop
 } def
-/currentuserparams {
-} def
-/setsystemparams {
-} def
+
 /currentsystemparams {
+    << /RealFormat (IEEE) /ByteOrder true /MaxFontCache 1048576 >>
 } def
+/setsystemparams { pop } def
 
 /setpagedevice {
     dup type /dicttype ne {

--- a/data/matrix.ps
+++ b/data/matrix.ps
@@ -160,8 +160,8 @@ end
     dup 0 eq { pop x y end /itransform cvx /undefinedresult signalerror } if
     1 exch div
     /invdet exch def
-    d x mul b y mul sub c f mul add d e mul sub invdet mul
-    c x mul neg a y mul add b e mul add a f mul sub invdet mul
+    d x mul c y mul sub c f mul add d e mul sub invdet mul
+    b x mul neg a y mul add b e mul add a f mul sub invdet mul
 end
 } def
 
@@ -177,8 +177,8 @@ end
     dup 0 eq { end /idtransform cvx /undefinedresult signalerror } if
     1 exch div
     /invdet exch def
-    d x mul b y mul sub invdet mul
-    c x mul neg a y mul add invdet mul
+    d x mul c y mul sub invdet mul
+    b x mul neg a y mul add invdet mul
 end
 } def
 

--- a/data/paint.ps
+++ b/data/paint.ps
@@ -56,18 +56,28 @@
         pstack()=
         hook
     } if
+    % merge the subpaths, separated by null, so that FillPoly scans
+    % them together and interior subpaths produce holes
+    [ exch
     {
         dup length 2 gt {
-            [ currentcolordict DEVICE /nativecolorspace get get exec
-            counttomark { currenttransfer exec counttomark 1 roll } repeat
-            counttomark 2 add -1 roll
-            DEVICE dup /FillPoly get exec
-            pop
-            %pstack()=
+            aload pop null
         }{
             pop
         } ifelse
     } forall
+    ]
+
+    dup length 2 gt {
+        [ currentcolordict DEVICE /nativecolorspace get get exec
+        counttomark { currenttransfer exec counttomark 1 roll } repeat
+        counttomark 2 add -1 roll
+        DEVICE dup /FillPoly get exec
+        pop
+        %pstack()=
+    }{
+        pop
+    } ifelse
 
     flushpage
     newpath
@@ -75,7 +85,10 @@
 
 % -  eofill  -
 % fill using even-odd rule
+% the scanline pairing in FillPoly is even-odd, so this
+% coincides with fill
 /eofill {
+    fill
 } def
 
 % -  stroke  -

--- a/data/path.ps
+++ b/data/path.ps
@@ -764,6 +764,10 @@ override%pop pop%bind def
 
         strokedict /justmoved get not { % draw join
             strokedict /ang get strokedict /oldang get sub
+            % the side reads from the turn within one revolution: the
+            % atan angles wrap at 360, so a difference below -180 is
+            % the same turn seen across the seam
+            dup 0 lt { 360 add } if
             /DEBUGSTROKE where { pop (C)= pstack()= } if
             dup 0 le exch 180 ge or { % right turn
 
@@ -832,6 +836,10 @@ override%pop pop%bind def
 
         strokedict /justmoved get not { % draw join
             strokedict /ang get strokedict /oldang get sub
+            % the side reads from the turn within one revolution: the
+            % atan angles wrap at 360, so a difference below -180 is
+            % the same turn seen across the seam
+            dup 0 lt { 360 add } if
             /DEBUGSTROKE where { pop (C)= pstack()= } if
             dup 0 le exch 180 ge or { % right turn
 
@@ -855,6 +863,10 @@ override%pop pop%bind def
 
             %draw final line join
             strokedict /firstang get strokedict /ang get sub
+            % the side reads from the turn within one revolution: the
+            % atan angles wrap at 360, so a difference below -180 is
+            % the same turn seen across the seam
+            dup 0 lt { 360 add } if
             dup 0 le exch 180 ge or { % right turn
 
                 strokedict /firstLL get aload pop

--- a/data/path.ps
+++ b/data/path.ps
@@ -944,7 +944,7 @@ override%pop pop%bind def
 
 /pathbbox {
     cpath length 0 eq {
-        0 0 0 0
+        /pathbbox cvx /nocurrentpoint signalerror
     }{
         << /minx 16#7fffffff /miny 1 index
             /maxx 1 index neg /maxy 1 index >> begin
@@ -954,8 +954,11 @@ override%pop pop%bind def
             0 1 2 index length 1 sub {
                 2 copy get
                 /data get
+                % stored points are device coordinates; the box is
+                % reported in user space (PLRM), so map each point
+                % back through the inverse CTM before accumulation
                 aload length 2 idiv
-                { maxmin } repeat
+                { itransform maxmin } repeat
                 pop
             } for
             pop pop

--- a/data/path.ps
+++ b/data/path.ps
@@ -659,9 +659,12 @@ override%pop pop%bind def
     3 1 roll sin mul     % rad*cos(ang) rad*sin(ang)
 } bind def
 
-% return currentlinewidth unless too small, otherwise 1
+% The stroke outline is constructed in device coordinates (strokepath
+% switches to the identity matrix), so its width is the line width as
+% transformed by the CTM. strokepath stashes that while the CTM is
+% still live; clamp to one pixel so thin strokes stay visible.
 /minlinewidth {
-    currentlinewidth
+    strokedict /devlinewidth get
     dup 1 lt { pop 1 } if
 } bind def
 
@@ -884,6 +887,10 @@ override%pop pop%bind def
 /strokepath {
     flattenpath          % convert all curve segments to line approximations
     dashpath             % apply dashing effect
+    strokedict /devlinewidth    % device-space width, while the CTM is live
+        currentlinewidth 0 dtransform
+        dup mul exch dup mul add sqrt
+    put
     matrix currentmatrix % stash matrix on stack
     matrix setmatrix     % use identity matrix
     cpath length 0 gt {

--- a/data/pgmimage.ps
+++ b/data/pgmimage.ps
@@ -53,10 +53,15 @@ DATA_DIR(/qsort.ps)strcat run
     currentdict end
     dup /.copydict get exec
     begin
+        % raster memory is not part of VM (PLRM 3.7.3): allocate the
+        % page buffer in global VM, which save/restore snapshots exempt,
+        % so marks placed inside a save survive its restore
+        currentglobal true setglobal
         /ImgData height array def
         0 1 height 1 sub {
             ImgData exch width string put
         } for
+        setglobal
     currentdict
     end }
 

--- a/data/pgmimage.ps
+++ b/data/pgmimage.ps
@@ -69,7 +69,9 @@ DATA_DIR(/qsort.ps)strcat run
     begin
         {
             .to-int exch .to-int exch
+            dup 0 lt { stop } if
             dup height ge { stop } if
+            1 index 0 lt { stop } if
             1 index width ge { stop } if
             ImgData exch get 3 1 roll exch
             255 mul cvi

--- a/data/ppmimage.ps
+++ b/data/ppmimage.ps
@@ -81,7 +81,9 @@ DATA_DIR(/qsort.ps)strcat run
     begin
         {
             .to-int exch .to-int exch
+            dup 0 lt { stop } if
             dup height ge { stop } if
+            1 index 0 lt { stop } if
             1 index width ge { stop } if
             ImgData exch get exch % r g b img(y) x
             5 2 roll % img(y) x r g b

--- a/data/ppmimage.ps
+++ b/data/ppmimage.ps
@@ -57,6 +57,10 @@ DATA_DIR(/qsort.ps)strcat run
     currentdict end
     dup /.copydict get exec
     begin
+        % raster memory is not part of VM (PLRM 3.7.3): allocate the
+        % page buffer in global VM, which save/restore snapshots exempt,
+        % so marks placed inside a save survive its restore
+        currentglobal true setglobal
         /ImgData height array def
         0 1 height 1 sub {
             ImgData exch width array
@@ -65,6 +69,7 @@ DATA_DIR(/qsort.ps)strcat run
             } for
             put
         } for
+        setglobal
     currentdict
     end } bind
 

--- a/data/ppmimage.ps
+++ b/data/ppmimage.ps
@@ -425,7 +425,7 @@ DATA_DIR(/qsort.ps)strcat run
             {
                 dup -16 bitshift =only( )=only
                 dup -8 bitshift 16#ff and =only( )=only
-                dup 16#ff and =only( )=only
+                16#ff and =only( )=only
             }forall
             (\n)=only
         }forall %data
@@ -450,7 +450,7 @@ DATA_DIR(/qsort.ps)strcat run
                 =string cvs dup length exch
                     f exch writestring
                     neg 4 add { f ( ) writestring } repeat
-                dup 16#ff and
+                16#ff and
                 =string cvs dup length exch
                     f exch writestring
                     neg 4 add { f ( ) writestring } repeat

--- a/data/test.ps
+++ b/data/test.ps
@@ -45,7 +45,7 @@ clear
 { = } stopped { $error /errorname get /stackunderflow eq check }{ fail } ifelse
 
 /== cvx ==
-{ == } stopped { end $error /errorname get /stackunderflow ne {fail} if }{ fail } ifelse
+{ == } stopped { $error /errorname get /stackunderflow ne {fail} if }{ fail } ifelse
 
 (abs)=
 4.5 abs 4.5 eq check

--- a/data/test.ps
+++ b/data/test.ps
@@ -445,8 +445,8 @@ d {} forall
 (ge)=
 (1: 4.2 4 ge check)=
 4.2 4 ge check
-(2: (abc) (d) ge check)=
-(abc) (d) ge check
+(2: (d) (abc) ge check)=
+(d) (abc) ge check
 (3: (aba) (ab) ge check)=
 (aba) (ab) ge check
 (4: (aba) (aba) ge check)=

--- a/data/test.ps
+++ b/data/test.ps
@@ -581,7 +581,7 @@ mark [ eq check
 (maxlength)=
 /mydict 8 dict def
 mydict length 0 eq check
-mydict maxlength 10 eq check
+mydict maxlength 8 eq check
 
 (mod)=
 5 3 mod 2 eq check

--- a/data/test.ps
+++ b/data/test.ps
@@ -15,6 +15,14 @@
     //fail
     ifelse
 } def
+% tolerance compare for transcendental results: real math is inexact
+% (and reals are single-precision here), so comparing atan/cos/exp/ln
+% output against a decimal literal with eq is unreliable.
+/nearly { sub abs 0.001 lt } def
+
+% breakhere is an xpost debugger breakpoint; stub it as a no-op on
+% interpreters that lack it so the suite is portable
+/breakhere where { pop }{ /breakhere { } def } ifelse
 
 %(test: loading graphics...)=
 %flush
@@ -98,14 +106,14 @@ false false and false eq check
 (a) (bcd) (ef) 3 array astore type /arraytype eq check
 
 (atan)=
-(1: 0 1 atan 0.0 eq check) ==
-0 1 atan 0.0 eq check
-(2: 1 0 atan 90.0 eq check) ==
-1 0 atan 90.0 eq check
-(3: -100 0 atan 270.0 eq check) ==
--100 0 atan 270.0 eq check
-(4: 4 4 atan 45.0 eq check) ==
-4 4 atan 45.0 eq check
+(1: 0 1 atan 0.0 nearly check) ==
+0 1 atan 0.0 nearly check
+(2: 1 0 atan 90.0 nearly check) ==
+1 0 atan 90.0 nearly check
+(3: -100 0 atan 270.0 nearly check) ==
+-100 0 atan 270.0 nearly check
+(4: 4 4 atan 45.0 nearly check) ==
+4 4 atan 45.0 nearly check
 
 %awidthshow
 %banddevice
@@ -182,8 +190,8 @@ a1 dup length array copy aload pop
 %copypage
 
 (cos)=
-0 cos 1.0 eq check
-90 cos 0.0 eq check
+0 cos 1.0 nearly check
+90 cos 0.0 nearly check
 
 (count)=
 clear count 0 eq check
@@ -369,10 +377,10 @@ errordict type /dicttype eq check
 {exit false check}loop
 
 (exp)=
-(1: 9 0.5 exp 3.0 eq check)=
-9 0.5 exp 3.0 eq check
-(2: -9 -1 exp -0.111111 eq check)=
--9 -1 exp -0.111111 eq check
+(1: 9 0.5 exp 3.0 nearly check)=
+9 0.5 exp 3.0 nearly check
+(2: -9 -1 exp -0.111111 nearly check)=
+-9 -1 exp -0.111111 nearly check
 
 (false)=
 false not check
@@ -550,16 +558,16 @@ mydict length 1 eq check
 %lineto
 
 (ln)=
-10 ln 2.30259 eq check
-100 ln 4.60517 eq check
+10 ln 2.30259 nearly check
+100 ln 4.60517 nearly check
 
 (load)=
 /avg {add 2 div} def
 /avg load 1 get 2 eq check
 
 (log)=
-10 log 1.0 eq check
-100 log 2.0 eq check
+10 log 1.0 nearly check
+100 log 2.0 nearly check
 
 %(loop)=
 %(lt)=
@@ -689,9 +697,14 @@ abc
 (1:)= pstack
  check (abc) eq check
 
-DATA_DIR(/readstring.ps)strcat run
-(2:)= pstack
- not check 0 3 getinterval (abc) eq check
+/DATA_DIR where {
+    pop
+    DATA_DIR(/readstring.ps)strcat run
+    (2:)= pstack
+     not check 0 3 getinterval (abc) eq check
+}{
+    (readstring-from-file test skipped: no DATA_DIR)=
+} ifelse
 
 %renderbands
 

--- a/doc/COMPAT
+++ b/doc/COMPAT
@@ -1,0 +1,69 @@
+Provenance of the interface vocabulary
+======================================
+
+Xpost's user-visible names come from three places, kept deliberately
+distinct. This note records which is which, and why the third group
+exists, so the interoperability intent is documented rather than
+implicit.
+
+
+== 1. Adobe-published specifications ==
+
+The default vocabulary. Wherever a published language specification
+names a concept, that name is used:
+
+  - The PostScript Language Reference Manual (3rd ed.): setpagedevice
+    and its parameters /PageSize, /HWResolution, /PageOffset and
+    /ProcessColorModel (PLRM3 section 6.2; /ProcessColorModel appears
+    among the colour-separation page device parameters alongside
+    /Separations and /SeparationColorNames); the /Separation and
+    /DeviceN colour spaces; the %stdout special file.
+
+  - The PDF specification (ISO 32000): the content-stream operators
+    the pdfwrite device emits (cs/scn, k/K, rg/RG, path operators),
+    the FunctionType 0 and 4 function dictionaries, the Type 4
+    calculator operator subset, and #xx name escaping.
+
+  - Adobe's pdfmark Reference: the /DOCINFO pdfmark.
+
+Future separating raster output should follow the same rule: PLRM3
+defines /Separations and /SeparationColorNames, so a separating device
+builds on those rather than adopting another implementation's device
+name or output-file naming scheme.
+
+
+== 2. Xpost's own names ==
+
+Everything internal is original to xpost or its contributors and
+resembles no other implementation's API: the device method protocol
+(Create, Destroy, Emit, PutPix, GetPix, DrawLine, DrawRect, FillRect,
+FillPoly, FillPath, StrokePath, BlendPix, Erase), the device keys
+/nativecolorspace, /dimensions, /VectorGlyphs, /VectorSyntax,
+/.colormodels, /.registersep and /Private, the dot-prefixed internal
+operators, and the device dictionary key /OutputFileName (original to
+xpost, 2013).
+
+Devices whose names are xpost's own choices: null, svgwrite, pgm, ppm.
+
+
+== 3. Deliberate compatibility names ==
+
+A small set of names is adopted from the vocabulary that existing
+PostScript job streams in the field actually use, so that such jobs
+run unmodified. Each is functionally required for that purpose; the
+set is kept minimal and confined to the job-stream boundary (nothing
+internal mirrors another implementation):
+
+  - /OutputDevice     setpagedevice key selecting the device
+  - /OutputFile       setpagedevice key naming the output path
+                      (mapped at the boundary onto xpost's own
+                      /OutputFileName)
+  - /TextAlphaBits    device feature enabling anti-aliased text
+  - /WhiteIsOpaque    device feature making white marks opaque on the
+                      transparent-page device
+  - pdfwrite, pngalpha, bbox    device names job streams select
+
+Additions to this group should name the job-stream requirement that
+forces them and should stay out of internal interfaces; anything a
+published Adobe specification already names belongs in group 1
+instead.

--- a/doc/Makefile.mk
+++ b/doc/Makefile.mk
@@ -28,6 +28,7 @@ doc: all
 endif
 
 EXTRA_DIST += \
+doc/COMPAT \
 doc/INTERNALS \
 doc/NEWINTERNALS \
 doc/MANUAL \

--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,22 @@ config_h = configuration_data()
 
 cc = meson.get_compiler('c')
 
+# Strict warning set matching the autotools build. warning_level=2 already
+# supplies -Wall -Wextra; these add the rest of the coverage. Unrecognised
+# flags are filtered out per compiler, so the list stays portable across gcc,
+# clang and mingw.
+strict_warnings = [
+  '-Wshadow',
+  '-Wdeclaration-after-statement',
+  '-Wmissing-prototypes',
+  '-Wstrict-prototypes',
+  '-Wpointer-arith',
+  '-Wwrite-strings',
+  '-Winline',
+  '-Wno-missing-field-initializers',
+]
+add_project_arguments(cc.get_supported_arguments(strict_warnings), language: 'c')
+
 # Release builds enable link-time optimization by default: it inlines the hot
 # cross-translation-unit interpreter accessors and is the single largest
 # speedup. debug and debugoptimized builds stay LTO-free for fast compiles, so

--- a/meson.build
+++ b/meson.build
@@ -260,6 +260,12 @@ test('interpreter',
   args: [ xpost_exe, files('data/test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' },
   timeout: 120)
+
+# Object semantics: file-object comparison and user-space pathbbox.
+test('semantics',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/semantics_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 #if get_option('nls') == true
 #  subdir('po')
 #endif

--- a/meson.build
+++ b/meson.build
@@ -398,6 +398,12 @@ test('op-cvs',
   args: [ xpost_exe, files('tests/op_cvs_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# array and string get/put require an integer index (a real is a typecheck).
+test('op-index-type',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_index_type_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -297,6 +297,16 @@ test('counttomark',
   args: [ xpost_exe, files('tests/counttomark_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
+# write the current-matrix array in place; that write must be backed up for
+# save/restore. Guards the regression where it was not -- a transform set inside
+# a save leaked past the restore, so dvips documents (casselman) rendered text
+# at a runaway scale and overflowed the operand stack.
+test('save-restore-ctm',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/save_restore_ctm_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # Error reporting: a top-level job error prints the standard Adobe error line
 # and flush notice; a clean quit or a caught error prints neither.
 test('error-format',

--- a/meson.build
+++ b/meson.build
@@ -327,6 +327,13 @@ test('op-path',
   args: [ xpost_exe, files('tests/op_path_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# status operator (PLRM 8.2): the (filename) form returns pages/bytes/referred/
+# created/true or false, alongside the existing file-object boolean form.
+test('op-status',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_status_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -360,6 +360,12 @@ test('op-packing',
   args: [ xpost_exe, files('tests/op_packing_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# vmreclaim (PLRM 8.2): 2 (local and global) reclaims local VM like 1 (local).
+test('op-vmreclaim',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_vmreclaim_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -305,6 +305,13 @@ test('op-math',
   args: [ xpost_exe, files('tests/op_math_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# Control operators (PLRM 8.2): repeat of a negative count is rangecheck (PLRM: the
+# count is a nonnegative integer), plus if/ifelse/for/loop/exit/stopped behaviour.
+test('op-control',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_control_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -379,6 +379,13 @@ test('op-radix',
   args: [ xpost_exe, files('tests/op_radix_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# cvi/cvr number conversion (PLRM 8.2): reject non-PostScript syntax; cvi of an
+# over-range real is rangecheck, not a wrap.
+test('op-cvi',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_cvi_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -320,6 +320,14 @@ test('op-matrix-gstate',
   args: [ xpost_exe, files('tests/op_matrix_gstate_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# A wrong-typed operand is a typecheck, not a stackunderflow, when a higher-arity
+# signature's operands are absent (PLRM/Distiller; gs differs for the matrix
+# builders, so this one is xpost-only).
+test('op-dispatch-typecheck',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_dispatch_typecheck_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # Path-construction operators (PLRM 8.2): currentpoint tracking, nocurrentpoint,
 # and arc endpoints on the axes (full-precision degrees).
 test('op-path',

--- a/meson.build
+++ b/meson.build
@@ -320,6 +320,13 @@ test('op-matrix-gstate',
   args: [ xpost_exe, files('tests/op_matrix_gstate_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# Path-construction operators (PLRM 8.2): currentpoint tracking, nocurrentpoint,
+# and arc endpoints on the axes (full-precision degrees).
+test('op-path',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_path_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -347,6 +347,13 @@ test('op-bytesavailable',
   args: [ xpost_exe, files('tests/op_bytesavailable_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# Operand restoration on error (PLRM 3.11): an operator error restores the
+# operands, including the integer types the program pushed.
+test('op-error-restore',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_error_restore_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -372,6 +372,13 @@ test('op-intoverflow',
   args: [ xpost_exe, files('tests/op_intoverflow_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# Radix number range (PLRM 3.2): unsigned twos-complement in the integer width,
+# limitcheck beyond it. Integer-width-specific, so xpost-only (see the file).
+test('op-radix',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_radix_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -290,6 +290,13 @@ test('save-restore',
   args: [ xpost_exe, files('tests/save_restore_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# counttomark and the [ ] / << >> constructors built on it: correctness plus
+# a performance guard -- an O(n^2) counttomark on a deep stack times the test out.
+test('counttomark',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/counttomark_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # Error reporting: a top-level job error prints the standard Adobe error line
 # and flush notice; a clean quit or a caught error prints neither.
 test('error-format',

--- a/meson.build
+++ b/meson.build
@@ -312,6 +312,14 @@ test('op-control',
   args: [ xpost_exe, files('tests/op_control_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# Matrix/coordinate and graphics-state operators (PLRM 8.2): a bad-length matrix
+# is rangecheck (was an out-of-bounds read), setlinecap/join outside 0..2 and
+# setmiterlimit below 1 are rangecheck, and rotate uses full-precision degrees.
+test('op-matrix-gstate',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_matrix_gstate_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -341,6 +341,12 @@ test('op-userparams',
   args: [ xpost_exe, files('tests/op_userparams_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# bytesavailable (PLRM 8.2): remaining bytes for a seekable file, -1 for a filter.
+test('op-bytesavailable',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_bytesavailable_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -283,6 +283,13 @@ test('semantics',
   args: [ xpost_exe, files('tests/semantics_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# Save/restore VM: drive the entity count past 65536 and require dicts and
+# arrays to revert exactly -- guards the saverec entity-width truncation.
+test('save-restore',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/save_restore_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # Error reporting: a top-level job error prints the standard Adobe error line
 # and flush notice; a clean quit or a caught error prints neither.
 test('error-format',

--- a/meson.build
+++ b/meson.build
@@ -297,6 +297,14 @@ test('counttomark',
   args: [ xpost_exe, files('tests/counttomark_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# Arithmetic/math operators (PLRM 8.2): zero-divisor mod/idiv are undefinedresult
+# not a SIGFPE, sqrt of a negative is rangecheck, and atan/sin/cos hit the PLRM
+# examples (a truncated RAD_PER_DEG had skewed them). From the 8.2 compliance campaign.
+test('op-math',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_math_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -366,6 +366,12 @@ test('op-vmreclaim',
   args: [ xpost_exe, files('tests/op_vmreclaim_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# Integer-literal range (PLRM 3.3.2): an over-range constant becomes a real.
+test('op-intoverflow',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_intoverflow_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -392,6 +392,12 @@ test('op-gstate-types',
   args: [ xpost_exe, files('tests/op_gstate_types_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# cvs yields --nostringval-- for every type outside the string-representable set.
+test('op-cvs',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_cvs_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -404,6 +404,12 @@ test('op-index-type',
   args: [ xpost_exe, files('tests/op_index_type_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# reading from a closed file reports end-of-data rather than raising an error.
+test('op-closed-read',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_closed_read_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -354,6 +354,12 @@ test('op-error-restore',
   args: [ xpost_exe, files('tests/op_error_restore_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# Array packing mode (PLRM 8.2): setpacking/currentpacking and read-only procs.
+test('op-packing',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_packing_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -266,6 +266,13 @@ test('semantics',
   find_program('tests/run-ps-test.sh'),
   args: [ xpost_exe, files('tests/semantics_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
+# Error reporting: a top-level job error prints the standard Adobe error line
+# and flush notice; a clean quit or a caught error prints neither.
+test('error-format',
+  find_program('tests/run-error-format-test.sh'),
+  args: [ xpost_exe ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 #if get_option('nls') == true
 #  subdir('po')
 #endif

--- a/meson.build
+++ b/meson.build
@@ -386,6 +386,12 @@ test('op-cvi',
   args: [ xpost_exe, files('tests/op_cvi_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# Graphics-state number parameters are reals (PLRM), matching Distiller and gs.
+test('op-gstate-types',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_gstate_types_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -334,6 +334,13 @@ test('op-status',
   args: [ xpost_exe, files('tests/op_status_test.ps') ],
   env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
 
+# User/system parameter operators (PLRM 8.2): current* return a parameter
+# dictionary and set* apply the parameters they recognise.
+test('op-userparams',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('tests/op_userparams_test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' })
+
 # save/restore (and gsave/grestore) must revert the CTM. scale/concat/rotate
 # write the current-matrix array in place; that write must be backed up for
 # save/restore. Guards the regression where it was not -- a transform set inside

--- a/meson.build
+++ b/meson.build
@@ -251,6 +251,15 @@ subdir('data')
 if get_option('doc')
   subdir('doc')
 endif
+
+# Core-interpreter conformance: run the PLRM operator-example suite through
+# the built interpreter and require its failcount to reach zero. The build-tree
+# binary is not installed, so point it at the source data via XPOST_DATA_DIR.
+test('interpreter',
+  find_program('tests/run-ps-test.sh'),
+  args: [ xpost_exe, files('data/test.ps') ],
+  env: { 'XPOST_DATA_DIR': meson.current_source_dir() / 'data' },
+  timeout: 120)
 #if get_option('nls') == true
 #  subdir('po')
 #endif

--- a/src/bin/meson.build
+++ b/src/bin/meson.build
@@ -11,7 +11,7 @@ if sys_windows
   xpost_bin_src += xpost_rc
 endif
 
-executable('xpost', xpost_bin_src,
+xpost_exe = executable('xpost', xpost_bin_src,
   c_args: '-DHAVE_CONFIG_H',
   dependencies: libxpost_dep,
   include_directories: [

--- a/src/bin/xpost_main.c
+++ b/src/bin/xpost_main.c
@@ -345,8 +345,16 @@ int main(int argc, char *argv[])
                     }
 
                 }
-                defs = realloc(defs, ++num_defs * sizeof *defs);
-                defs[num_defs-1] = strdup(define);
+                {
+                    char **tmp = realloc(defs, (num_defs + 1) * sizeof *defs);
+                    if (!tmp)
+                    {
+                        XPOST_LOG_ERR("out of memory");
+                        goto quit_xpost;
+                    }
+                    defs = tmp;
+                    defs[num_defs++] = strdup(define);
+                }
             }
             else if ((!strcmp(argv[i], "-q")) ||
                      (!strcmp(argv[i], "--quiet")))

--- a/src/lib/xpost_array.c
+++ b/src/lib/xpost_array.c
@@ -162,9 +162,9 @@ int xpost_array_put_memory(Xpost_Memory_File *mem,
     if (!xpost_save_ent_is_saved(mem, xpost_object_get_ent(a)))
         if (!xpost_save_save_ent(mem, arraytype, a.comp_.sz, xpost_object_get_ent(a)))
             return VMerror;
-    if (i > a.comp_.sz)
+    if (i >= a.comp_.sz)
     {
-        XPOST_LOG_ERR("cannot put value in array (rangecheck) %u > [%u]", i, a.comp_.sz);
+        XPOST_LOG_ERR("cannot put value in array (rangecheck) %u >= [%u]", i, a.comp_.sz);
         /*breakhere((Xpost_Context *)mem);*/
         return rangecheck;
     }

--- a/src/lib/xpost_array.c
+++ b/src/lib/xpost_array.c
@@ -37,6 +37,7 @@
 #endif
 
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h> /* size_t */
 
 #include "xpost.h"

--- a/src/lib/xpost_context.c
+++ b/src/lib/xpost_context.c
@@ -462,7 +462,6 @@ unsigned int xpost_context_fork3(Xpost_Context *ctx,
 
     xpost_stack_push(newctx->lo, newctx->ds,
             xpost_stack_bottomup_fetch(ctx->lo, ctx->ds, 0)); // systemdict
-    printf("fork cid %u, ctx->id %u\n", newcid, newctx->id);
     return newcid;
 }
 

--- a/src/lib/xpost_context.c
+++ b/src/lib/xpost_context.c
@@ -315,6 +315,7 @@ int xpost_context_init(Xpost_Context *ctx,
     ctx->es_over = 0;
     ctx->os_over = 0;
     ctx->ds_over = 0;
+    ctx->onerr_run = 0;
     ctx->xpost_interpreter_cid_init = xpost_interpreter_cid_init;
     ctx->xpost_interpreter_alloc_local_memory = xpost_interpreter_alloc_local_memory;
     ctx->xpost_interpreter_alloc_global_memory = xpost_interpreter_alloc_global_memory;

--- a/src/lib/xpost_context.c
+++ b/src/lib/xpost_context.c
@@ -312,6 +312,9 @@ int xpost_context_init(Xpost_Context *ctx,
     }
     ctx->event_handler = null;
     ctx->ignoreinvalidaccess = 0;
+    ctx->es_over = 0;
+    ctx->os_over = 0;
+    ctx->ds_over = 0;
     ctx->xpost_interpreter_cid_init = xpost_interpreter_cid_init;
     ctx->xpost_interpreter_alloc_local_memory = xpost_interpreter_alloc_local_memory;
     ctx->xpost_interpreter_alloc_global_memory = xpost_interpreter_alloc_global_memory;

--- a/src/lib/xpost_context.h
+++ b/src/lib/xpost_context.h
@@ -95,6 +95,11 @@ struct _Xpost_Context {
 
     int ignoreinvalidaccess; //briefly allow invalid access to put userdict in systemdict (per PLRM)
 
+    unsigned int es_run_base; /**< exec-stack depth at xpost_run entry;
+                                    a completed run is truncated back to
+                                    this depth so its scheduling frames
+                                    cannot accumulate across jobs */
+
     int (*xpost_interpreter_cid_init)(unsigned int *cid);
     Xpost_Memory_File *(*xpost_interpreter_alloc_local_memory)(void);
     Xpost_Memory_File *(*xpost_interpreter_alloc_global_memory)(void);

--- a/src/lib/xpost_context.h
+++ b/src/lib/xpost_context.h
@@ -83,6 +83,12 @@ struct _Xpost_Context {
     unsigned char op_restore_idx[8];
     Xpost_Object op_restore_val[8];
 
+    /* array-packing mode (setpacking/currentpacking): when set, the scanner
+       builds { } procedures read-only. packing_hist records the mode at each
+       save level so restore reverts it, as the parameter is save/restore-subject */
+    int packing;
+    unsigned char packing_hist[256];
+
     /*@dependent@*/
     Xpost_Memory_File *gl; /**< global VM */
     /*@dependent@*/

--- a/src/lib/xpost_context.h
+++ b/src/lib/xpost_context.h
@@ -99,6 +99,10 @@ struct _Xpost_Context {
                                    holds off a re-raise until depth recedes */
     int os_over;              /**< likewise for the operand stack */
     int ds_over;              /**< likewise for the dictionary stack */
+    int onerr_run;            /**< consecutive errors handled without the run
+                                   reaching `stop`; a runaway error cascade
+                                   (an error raised from within the error
+                                   machinery itself) drives this without bound */
 
     unsigned int es_run_base; /**< exec-stack depth at xpost_run entry;
                                     a completed run is truncated back to

--- a/src/lib/xpost_context.h
+++ b/src/lib/xpost_context.h
@@ -76,6 +76,13 @@ struct _Xpost_Context {
 
     Xpost_Object currentobject;  /**< currently-executing object, for error() */
 
+    /* operands the dispatcher coerced from integer to real for the current
+       operator; an error restores them to the originals the program pushed,
+       as PLRM 3.11 requires. Empty for operators that coerce nothing. */
+    int op_restore_n;
+    unsigned char op_restore_idx[8];
+    Xpost_Object op_restore_val[8];
+
     /*@dependent@*/
     Xpost_Memory_File *gl; /**< global VM */
     /*@dependent@*/

--- a/src/lib/xpost_context.h
+++ b/src/lib/xpost_context.h
@@ -95,6 +95,11 @@ struct _Xpost_Context {
 
     int ignoreinvalidaccess; //briefly allow invalid access to put userdict in systemdict (per PLRM)
 
+    int es_over;              /**< the exec-stack ceiling has been reported;
+                                   holds off a re-raise until depth recedes */
+    int os_over;              /**< likewise for the operand stack */
+    int ds_over;              /**< likewise for the dictionary stack */
+
     unsigned int es_run_base; /**< exec-stack depth at xpost_run entry;
                                     a completed run is truncated back to
                                     this depth so its scheduling frames

--- a/src/lib/xpost_dev_generic.c
+++ b/src/lib/xpost_dev_generic.c
@@ -73,7 +73,6 @@ static Xpost_Object nameexec;
 static Xpost_Object namerepeat;
 static Xpost_Object namecvx;
 static Xpost_Object nameRbracket;
-static Xpost_Object nameImgData;
 
 char *xpost_device_get_filename(Xpost_Context *ctx, Xpost_Object devdic)
 {
@@ -314,8 +313,9 @@ int _fillpoly(Xpost_Context *ctx,
     int numlines;
     /* Xpost_Object x1, y1, x2, y2; */
     Xpost_Object drawline;
-    struct point *points, *intersections;
+    struct point *points, *intersections, *tmp;
     int i, j;
+    int cap;
     real yscan;
     real minx = (real)0x7ffffff;
     real miny = minx;
@@ -347,8 +347,6 @@ int _fillpoly(Xpost_Context *ctx,
 
     /* extract polygon vertices from ps array */
     points = malloc(poly.comp_.sz * sizeof *points);
-    if (!points)
-        return VMerror;
     for (i = 0; i < poly.comp_.sz; i++)
     {
         Xpost_Object pair, x, y;
@@ -389,7 +387,9 @@ int _fillpoly(Xpost_Context *ctx,
         return 0;
     }
 
-    intersections = calloc((size_t)(maxy - miny), 2 * 2 * sizeof *intersections);
+    /* a complex polygon may cross a scanline many times; grow as needed */
+    cap = 4 * ((int)(maxy - miny) + 1);
+    intersections = calloc(cap, sizeof *intersections);
     if (!intersections)
     {
         free(points);
@@ -409,6 +409,18 @@ int _fillpoly(Xpost_Context *ctx,
                            (real)(maxx + 0.5), yscan,
                            &rx, &ry))
             {
+                if (j == cap)
+                {
+                    cap *= 2;
+                    tmp = realloc(intersections, cap * sizeof *intersections);
+                    if (!tmp)
+                    {
+                        free(points);
+                        free(intersections);
+                        return VMerror;
+                    }
+                    intersections = tmp;
+                }
                 intersections[j].x = rx;
                 intersections[j].y = ry;
                 j++;
@@ -541,69 +553,6 @@ int _fillpoly(Xpost_Context *ctx,
     return 0;
 }
 
-/* Fast FillRect for grayscale (DeviceGray) array-of-strings devices such as
-   PGMIMAGE. Writes the ImgData row strings directly rather than looping over
-   PutPix in PostScript; erasepage clears the whole page through FillRect, so
-   the per-pixel interpreter overhead otherwise dominates page emission.
-   Mirrors PGMIMAGE's FillRect/PutPix handling exactly: value scaled by 255 and
-   truncated to a byte, coordinates floored, negative extents normalised,
-   inclusive end coordinates, and bounds clipping (rows via ImgData length,
-   columns via each row string's length). */
-static
-int _fillrectgray(Xpost_Context *ctx,
-                  Xpost_Object val,
-                  Xpost_Object x,
-                  Xpost_Object y,
-                  Xpost_Object w,
-                  Xpost_Object h,
-                  Xpost_Object devdic)
-{
-    Xpost_Object imgdata, row;
-    double dx, dy, dw, dh;
-    int height, iy, iy0, iy1, ix0, ix1;
-    unsigned char b;
-
-    imgdata = xpost_dict_get(ctx, devdic, nameImgData);
-    if (xpost_object_get_type(imgdata) != arraytype)
-        return undefined;
-    height = imgdata.comp_.sz;
-
-    /* value -> byte, matching PGMIMAGE PutPix "255 mul cvi put" */
-    b = (unsigned char)(int)((xpost_object_get_type(val) == realtype
-                              ? val.real_.val : (double)val.int_.val) * 255.0);
-
-    dx = xpost_object_get_type(x) == realtype ? x.real_.val : (double)x.int_.val;
-    dy = xpost_object_get_type(y) == realtype ? y.real_.val : (double)y.int_.val;
-    dw = xpost_object_get_type(w) == realtype ? w.real_.val : (double)w.int_.val;
-    dh = xpost_object_get_type(h) == realtype ? h.real_.val : (double)h.int_.val;
-
-    /* normalise negative extents, then form inclusive end coords */
-    if (dw < 0) { dw = -dw; dx -= dw; }
-    if (dh < 0) { dh = -dh; dy -= dh; }
-    ix0 = (int)floor(dx);
-    iy0 = (int)floor(dy);
-    ix1 = (int)floor(dx + dw);
-    iy1 = (int)floor(dy + dh);
-
-    /* clip rows to the device */
-    if (iy0 < 0) iy0 = 0;
-    if (iy1 > height - 1) iy1 = height - 1;
-
-    for (iy = iy0; iy <= iy1; iy++)
-    {
-        int width, cx0, cx1;
-        row = xpost_array_get(ctx, imgdata, iy);
-        width = row.comp_.sz;
-        cx0 = ix0 < 0 ? 0 : ix0;
-        cx1 = ix1 > width - 1 ? width - 1 : ix1;
-        if (cx0 <= cx1)
-            memset(xpost_string_get_pointer(ctx, row) + cx0, b,
-                   (size_t)(cx1 - cx0 + 1));
-    }
-
-    return 0;
-}
-
 int xpost_oper_init_generic_device_ops(Xpost_Context *ctx,
                                        Xpost_Object sd)
 {
@@ -618,11 +567,7 @@ int xpost_oper_init_generic_device_ops(Xpost_Context *ctx,
 
     op = xpost_operator_cons(ctx, ".yxsort", (Xpost_Op_Func)_yxsort, 0, 1, arraytype); INSTALL;
     op = xpost_operator_cons(ctx, ".fillpoly", (Xpost_Op_Func)_fillpoly, 0, 2, arraytype, dicttype); INSTALL;
-    op = xpost_operator_cons(ctx, ".fillrectgray", (Xpost_Op_Func)_fillrectgray, 0, 6,
-            numbertype, numbertype, numbertype, numbertype, numbertype, dicttype); INSTALL;
     if (xpost_object_get_type((namewidth = xpost_name_cons(ctx, "width"))) == invalidtype)
-        return VMerror;
-    if (xpost_object_get_type((nameImgData = xpost_name_cons(ctx, "ImgData"))) == invalidtype)
         return VMerror;
     if (xpost_object_get_type((namenativecolorspace = xpost_name_cons(ctx, "nativecolorspace"))) == invalidtype)
         return VMerror;

--- a/src/lib/xpost_dev_generic.c
+++ b/src/lib/xpost_dev_generic.c
@@ -84,6 +84,11 @@ char *xpost_device_get_filename(Xpost_Context *ctx, Xpost_Object devdic)
 
     filenamestr = xpost_dict_get(ctx, devdic,
                                  xpost_name_cons(ctx, "OutputFileName"));
+    /* a device dict without a string OutputFileName -- e.g. after a program
+       switches devices with setpagedevice, which records the name in userdict
+       rather than the device dict -- must not be read as a string */
+    if (xpost_object_get_type(filenamestr) != stringtype)
+        return NULL;
     filename = malloc(filenamestr.comp_.sz + 1);
     if (filename)
     {

--- a/src/lib/xpost_dev_generic.c
+++ b/src/lib/xpost_dev_generic.c
@@ -470,6 +470,9 @@ int _fillpoly(Xpost_Context *ctx,
         xpost_stack_push(ctx->lo, ctx->os, y2);
     */
 
+    /*the loop body and continuation are built from operator objects,
+     not executable names, so a user definition of /roll or /repeat on
+     the dict stack cannot capture them mid-fill */
     /*then we'll use a repeat loop to call DrawLine
      on each set of 4 numbers. But in order to treat the color space
      generically, we construct the loop body dynamically. */
@@ -503,7 +506,7 @@ int _fillpoly(Xpost_Context *ctx,
             xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons(3)); /* color components to move */
             break;
     }
-    xpost_stack_push(ctx->lo, ctx->os, xpost_object_cvx( nameroll));
+    xpost_stack_push(ctx->lo, ctx->os, xpost_operator_cons(ctx, "roll", NULL, 0, 0));
 
       /*at this point (in constructing the (color-space-generic) loop-body) we have the desired stack picture:
 
@@ -521,7 +524,7 @@ int _fillpoly(Xpost_Context *ctx,
 
     /*if drawline is a procedure, we also need to call exec */
     if (xpost_object_get_type(drawline) == arraytype)
-        xpost_stack_push(ctx->lo, ctx->os, nameexec);
+        xpost_stack_push(ctx->lo, ctx->os, xpost_operator_cons(ctx, "exec", NULL, 0, 0));
 
     /*--the rest of the code here calls-back to postscript (by "continuation")
         by pushing executable names on the execution-stack, and then returns.
@@ -555,9 +558,9 @@ int _fillpoly(Xpost_Context *ctx,
       So the sequence in C is:
      */
 
-    xpost_stack_push(ctx->lo, ctx->es, xpost_object_cvx( namerepeat));
-    xpost_stack_push(ctx->lo, ctx->es, xpost_object_cvx( namecvx));
-    xpost_stack_push(ctx->lo, ctx->es, xpost_object_cvx( nameRbracket));
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons(ctx, "repeat", NULL, 0, 0));
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons(ctx, "cvx", NULL, 0, 0));
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons(ctx, "]", NULL, 0, 0));
 
     /*performance could be increased by factoring-out calls to xpost_name_cons()  ... DONE!
       or using opcode shortcuts for Rbracket & cvx (or just the arrtomark() function) and repeat.

--- a/src/lib/xpost_dev_generic.c
+++ b/src/lib/xpost_dev_generic.c
@@ -60,6 +60,9 @@ struct point
     real x, y;
 };
 
+/* marks a subpath separator in a point list */
+#define SUBPATH_BREAK ((real)-0x7ffffff)
+
 /* FIXME: re-entrancy */
 static Xpost_Context *localctx;
 
@@ -345,13 +348,20 @@ int _fillpoly(Xpost_Context *ctx,
         return unregistered;
     }
 
-    /* extract polygon vertices from ps array */
+    /* extract polygon vertices from ps array;
+       null elements separate subpaths */
     points = malloc(poly.comp_.sz * sizeof *points);
     for (i = 0; i < poly.comp_.sz; i++)
     {
         Xpost_Object pair, x, y;
 
         pair = xpost_array_get(ctx, poly, i);
+        if (xpost_object_get_type(pair) != arraytype)
+        {
+            points[i].x = SUBPATH_BREAK;
+            points[i].y = SUBPATH_BREAK;
+            continue;
+        }
         x = xpost_array_get(ctx, pair, 0);
         y = xpost_array_get(ctx, pair, 1);
         if (xpost_object_get_type(x) == integertype)
@@ -368,6 +378,8 @@ int _fillpoly(Xpost_Context *ctx,
     /* find bounding box */
     for (i = 0; i < poly.comp_.sz; i++)
     {
+        if (points[i].x == SUBPATH_BREAK)
+            continue;
         if (points[i].x < minx)
             minx = points[i].x;
         if (points[i].x > maxx)
@@ -401,6 +413,8 @@ int _fillpoly(Xpost_Context *ctx,
     {
         real rx, ry;
 
+        if (points[i].x == SUBPATH_BREAK || points[i+1].x == SUBPATH_BREAK)
+            continue;
         for (yscan = (real)(miny + 0.5); yscan < maxy; yscan += 1.0)
         {
             if (_intersect(points[i].x, points[i].y,

--- a/src/lib/xpost_dev_png.c
+++ b/src/lib/xpost_dev_png.c
@@ -80,6 +80,7 @@ typedef struct
     png_infop           info_ptr;
     Xpost_Png_Buffer *buf;
     unsigned int interlaced : 1;
+    unsigned int emitted : 1;
 } PrivateData;
 
 static Xpost_Object namePrivate;
@@ -149,6 +150,7 @@ int _create_cont(Xpost_Context *ctx,
 
     private.width = width;
     private.height = height;
+    private.emitted = 0;
 
     /*
      *
@@ -396,6 +398,11 @@ int _emit(Xpost_Context *ctx,
     xpost_memory_get(xpost_context_select_memory(ctx, privatestr),
             xpost_object_get_ent(privatestr), 0, sizeof private, &private);
 
+    /* libpng reports errors by longjmp: aim it at this call, not at
+       the long-gone frame that created the device */
+    if (setjmp(png_jmpbuf(private.png_ptr)))
+        return ioerror;
+
 #ifdef PNG_WRITE_INTERLACING_SUPPORTED
     num_passes = png_set_interlace_handling(private.png_ptr);
 #endif
@@ -410,6 +417,11 @@ int _emit(Xpost_Context *ctx,
             data += 3 * private.width;
         }
     }
+
+    private.emitted = 1;
+    xpost_memory_put(xpost_context_select_memory(ctx, privatestr),
+                     xpost_object_get_ent(privatestr), 0,
+                     sizeof(private), &private);
 
     /* pass data back to client application */
     {
@@ -443,7 +455,16 @@ int _destroy(Xpost_Context *ctx,
                      sizeof(private), &private);
 
     free(private.buf);
-    png_write_end(private.png_ptr, private.info_ptr);
+    /* a device destroyed without a page emitted (an error ended the
+       job first) has no image to finalise, and libpng would reject the
+       trailer; aim its longjmp here either way, so a write error while
+       finalising cannot jump into the dead frame that created the
+       device */
+    if (setjmp(png_jmpbuf(private.png_ptr)) == 0)
+    {
+        if (private.emitted)
+            png_write_end(private.png_ptr, private.info_ptr);
+    }
     png_destroy_write_struct(&private.png_ptr, (png_infopp) & private.info_ptr);
     png_destroy_info_struct(private.png_ptr, (png_infopp) & private.info_ptr);
     fclose(private.f);

--- a/src/lib/xpost_dict.c
+++ b/src/lib/xpost_dict.c
@@ -646,6 +646,13 @@ int xpost_dict_put_memory(Xpost_Context *ctx,
         if (!xpost_object_is_writeable(ctx, d))
             return invalidaccess;
 
+    /* canonicalise the key first: converting a new string key to a name
+       allocates, which can collect or move the memory file; every
+       pointer derived before that point would be stale */
+    k = clean_key(ctx, k);
+    if (xpost_object_get_type(k) == invalidtype)
+        return VMerror;
+
     if (!xpost_save_ent_is_saved(mem, xpost_object_get_ent(d)))
         if (!xpost_save_save_ent(mem, dicttype, 0, xpost_object_get_ent(d)))
             return VMerror;
@@ -690,10 +697,8 @@ int xpost_dict_put_memory(Xpost_Context *ctx,
         xpost_memory_table_get_addr(mem, xpost_object_get_ent(d), &ad);
         dp = (void *)(mem->base + ad);
         ++ dp->nused;
-        r->key = clean_key(ctx, k);
-        r->hash = hash(r->key);
-        if (xpost_object_get_type(r->key) == invalidtype)
-            return VMerror;
+        r->key = k; /* canonicalised above */
+        r->hash = hash(k);
     }
     else if (xpost_object_get_type(r->value) == magictype)
     {
@@ -763,13 +768,13 @@ int xpost_dict_undef_memory(Xpost_Context *ctx,
         if (!xpost_save_save_ent(mem, dicttype, 0, xpost_object_get_ent(d)))
             return VMerror;
 
+    k = clean_key(ctx, k); /* may allocate: derive pointers after */
+    if (xpost_object_get_type(k) == invalidtype)
+        return VMerror;
+
     xpost_memory_table_get_addr(mem, xpost_object_get_ent(d), &ad);
     dp = (void *)(mem->base + ad);
     tp = (void *)(mem->base + ad + sizeof(dichead));
-
-    k = clean_key(ctx, k);
-    if (xpost_object_get_type(k) == invalidtype)
-        return VMerror;
 
     e = diclookup(ctx, mem, d, k); /*find slot for key */
     if (e == NULL || e == invalidrec || xpost_object_get_type(e->key) == nulltype)

--- a/src/lib/xpost_dict.c
+++ b/src/lib/xpost_dict.c
@@ -182,9 +182,18 @@ cont:
                                 && xpost_object_get_ent(L) == xpost_object_get_ent(R)
                                 && L.comp_.off == R.comp_.off ); /* 0 if all eq */
 
-        case stringtype: return L.comp_.sz == R.comp_.sz ?
-                                memcmp(xpost_string_get_pointer(ctx, L), xpost_string_get_pointer(ctx, R), L.comp_.sz) :
-                                L.comp_.sz - R.comp_.sz;
+        case stringtype:
+        {
+            /* strings compare lexicographically, element by element;
+               where one is a prefix of the other the shorter is less
+               (PLRM, gt/ge/lt/le). Comparing by length alone is wrong:
+               (abc) is less than (d), not greater. */
+            unsigned int ln = L.comp_.sz, rn = R.comp_.sz;
+            unsigned int n = ln < rn ? ln : rn;
+            int c = memcmp(xpost_string_get_pointer(ctx, L),
+                           xpost_string_get_pointer(ctx, R), n);
+            return c != 0 ? c : (int)ln - (int)rn;
+        }
         case filetype: return xpost_file_get_file_pointer(ctx->lo, L) == xpost_file_get_file_pointer(ctx->lo, R);
     }
 }

--- a/src/lib/xpost_dict.c
+++ b/src/lib/xpost_dict.c
@@ -241,6 +241,8 @@ Xpost_Object xpost_dict_cons_memory (Xpost_Memory_File *mem,
     unsigned int ent;
     unsigned int hashnull;
 
+    unsigned int reqsz = sz; /* nominal capacity, as maxlength reports it */
+
     if (sz < 8) sz = 8;
     sz = (unsigned int)ceil((double)sz * 1.25);
 
@@ -270,7 +272,7 @@ Xpost_Object xpost_dict_cons_memory (Xpost_Memory_File *mem,
     dp->tag = d.tag;
     dp->sz = sz;
     dp->nused = 0;
-    dp->pad = 0;
+    dp->pad = reqsz; /* remember the requested capacity for maxlength */
 
     tp = (void *)(mem->base + ad + sizeof(dichead)); /* clear table */
     hashnull = hash(null);
@@ -315,7 +317,8 @@ unsigned int xpost_dict_length_memory (Xpost_Memory_File *mem,
     return dp->nused;
 }
 
-/* get the sz field from the dichead */
+/* get the sz field from the dichead: the internal hash-table size,
+   used to decide when the dict is full and how large to grow it */
 unsigned int xpost_dict_max_length_memory (Xpost_Memory_File *mem,
                       Xpost_Object d)
 {
@@ -324,6 +327,19 @@ unsigned int xpost_dict_max_length_memory (Xpost_Memory_File *mem,
     xpost_memory_table_get_addr(mem, xpost_object_get_ent(d), &da);
     dp = (void *)(mem->base + da);
     return dp->sz;
+}
+
+/* the nominal capacity the dict was created with, which maxlength must
+   report; the internal size above is over-allocated (min 8, x1.25) and
+   would over-report */
+unsigned int xpost_dict_requested_length_memory (Xpost_Memory_File *mem,
+                      Xpost_Object d)
+{
+    unsigned int da;
+    dichead *dp;
+    xpost_memory_table_get_addr(mem, xpost_object_get_ent(d), &da);
+    dp = (void *)(mem->base + da);
+    return dp->pad;
 }
 
 /*

--- a/src/lib/xpost_dict.c
+++ b/src/lib/xpost_dict.c
@@ -194,7 +194,8 @@ cont:
                            xpost_string_get_pointer(ctx, R), n);
             return c != 0 ? c : (int)ln - (int)rn;
         }
-        case filetype: return xpost_file_get_file_pointer(ctx->lo, L) == xpost_file_get_file_pointer(ctx->lo, R);
+        /* equal underlying streams compare equal (0), like every case above */
+        case filetype: return xpost_file_get_file_pointer(ctx->lo, L) != xpost_file_get_file_pointer(ctx->lo, R);
     }
 }
 

--- a/src/lib/xpost_dict.c
+++ b/src/lib/xpost_dict.c
@@ -158,15 +158,16 @@ cont:
         case booleantype: /*@fallthrough@*/
         case integertype: return L.int_.val - R.int_.val;
 
-        case realtype: return (fabs(L.real_.val - R.real_.val) < 0.0001)?
-                                0:
-                                L.real_.val - R.real_.val > 0? 1: -1;
+        /* numbers compare exactly: this function also backs
+           the relational operators */
+        case realtype: return L.real_.val < R.real_.val ? -1 :
+                              L.real_.val > R.real_.val ? 1 : 0;
         case extendedtype:
         {
             double l,r;
             l = xpost_dict_convert_extended_to_double(L);
             r = xpost_dict_convert_extended_to_double(R);
-            return (fabs(l - r) < 0.0001) ? 0 : l - r > 0? 1: -1;
+            return l < r ? -1 : l > r ? 1 : 0;
         }
 
         case operatortype:  return L.mark_.padw - R.mark_.padw;

--- a/src/lib/xpost_dict.c
+++ b/src/lib/xpost_dict.c
@@ -539,7 +539,7 @@ dicrec *diclookup(Xpost_Context *ctx,
         return invalidrec;
     dp = (void *)(mem->base + ad);
     tp = (void *)(mem->base + ad + sizeof(dichead));
-    sz = (dp->sz + 1);
+    sz = DICTABN(dp->sz);
 
     hashval = hash(k);
     h = hashval % sz;
@@ -740,7 +740,11 @@ int xpost_dict_put(Xpost_Context *ctx,
     return xpost_dict_put_memory(ctx, xpost_context_select_memory(ctx, d), d, k, v);
 }
 
-/* undefine key from dict */
+/* undefine key from dict.
+
+   after emptying the slot, re-slot the entries that follow it in the
+   probe cluster so no entry is left unreachable beyond the new hole
+   (Knuth TAOCP vol.3, 6.4 Algorithm R). */
 int xpost_dict_undef_memory(Xpost_Context *ctx,
         Xpost_Memory_File *mem,
         Xpost_Object d,
@@ -751,12 +755,9 @@ int xpost_dict_undef_memory(Xpost_Context *ctx,
     dichead *dp;
     dicrec *tp;
     unsigned int sz;
-    unsigned int hashval;
-    unsigned int h;
+    unsigned int hashnull;
     unsigned int i;
-    unsigned int last = 0;
-    int lastisset = 0;
-    int found = 0;
+    unsigned int j;
 
     if (!xpost_save_ent_is_saved(mem, xpost_object_get_ent(d)))
         if (!xpost_save_save_ent(mem, dicttype, 0, xpost_object_get_ent(d)))
@@ -771,68 +772,39 @@ int xpost_dict_undef_memory(Xpost_Context *ctx,
         return VMerror;
 
     e = diclookup(ctx, mem, d, k); /*find slot for key */
-    if (e == NULL || e == invalidrec || xpost_dict_compare_objects(ctx,e->key,null) == 0)
+    if (e == NULL || e == invalidrec || xpost_object_get_type(e->key) == nulltype)
     {
         return undefined;
     }
 
-    /*find last chained key and value with same hash */
-    /*FIXME: need to repeat this process with this 'last chained key with same hash'
-      until the key we're clearing is the actual last key in the chain, recursively. */
     sz = DICTABN(dp->sz);
-    hashval = hash(k);
-    h = hashval % sz;
+    hashnull = hash(null);
 
-    for (i = h; i < sz; i++)
-    {
-        if (h == hash(tp[i].key) % sz)
-        {
-            last = i;
-            lastisset = 1;
-        }
-        else if (xpost_dict_compare_objects(ctx, tp[i].key, null) == 0)
-        {
-            if (lastisset)
-            {
-                found = 1;
-                break;
-            }
-        }
-    }
+    j = e - tp; /* empty the slot */
+    tp[j].key = null;
+    tp[j].hash = hashnull;
+    tp[j].value = null;
+    --dp->nused;
 
-    if (!found)
+    i = j;
+    while (1) /* re-slot the remainder of the cluster */
     {
-        for (i = 0; i < h; i++)
-        {
-            if (h == hash(tp[i].key) % sz)
-            {
-                last = i;
-                lastisset = 1;
-            }
-            else if (xpost_dict_compare_objects(ctx, tp[i].key, null) == 0)
-            {
-                if (lastisset)
-                {
-                    found = 1;
-                    break;
-                }
-            }
-        }
-    }
+        unsigned int home;
 
-    if (found) /* f found: move last key and value to slot */
-    {
-        e->key = tp[last].key;
-        e->value = tp[last].value;
-        tp[last].key = null;
-        tp[last].hash = hash(tp[last].key);
-        tp[last].value = null;
-    }
-    else /* ot found: write null over key and value */
-    {
-        e->key = null;
-        tp[last].hash = hash(tp[last].key);
-        e->value = null;
+        i = (i + 1) % sz;
+        if (xpost_object_get_type(tp[i].key) == nulltype)
+            break;
+        /* move entry i into the hole at j unless its home slot lies
+           cyclically within (j, i], in which case it is still reachable */
+        home = tp[i].hash % sz;
+        if (i > j ? (home <= j || home > i) : (home <= j && home > i))
+        {
+            tp[j] = tp[i];
+            tp[i].key = null;
+            tp[i].hash = hashnull;
+            tp[i].value = null;
+            j = i;
+        }
     }
 
     return 0;

--- a/src/lib/xpost_dict.c
+++ b/src/lib/xpost_dict.c
@@ -439,7 +439,7 @@ Xpost_Object consextended (double d)
 
     r.number = d;
     o.extended_.tag = extendedtype;
-    o.extended_.sign_exp = (r.bits >> 52) & 0x7FF;
+    o.extended_.sign_exp = (r.bits >> 52) & 0xFFF;
     o.extended_.fraction = (r.bits >> 20) & 0xFFFFFFFF;
     return o;
 }

--- a/src/lib/xpost_dict.c
+++ b/src/lib/xpost_dict.c
@@ -204,12 +204,23 @@ static
 unsigned int hash(Xpost_Object k)
 {
     unsigned int h;
-    h = ( (xpost_object_get_type(k)
-            | (k.comp_.tag & XPOST_OBJECT_TAG_DATA_FLAG_BANK))
-            << 1) /* ignore flags (except BANK!) */
-        + (k.comp_.sz << 3)
-        + (xpost_object_get_ent(k) << 7)
-        + (k.comp_.off << 5);
+    /* names are identified by bank and name-stack index alone;
+       xpost_object_get_ent() is -1 for non-composites, so without this
+       case every name key would hash identically */
+    if (xpost_object_get_type(k) == nametype)
+        h = ( (nametype
+                | (k.mark_.tag & XPOST_OBJECT_TAG_DATA_FLAG_BANK))
+                << 1)
+            + ((unsigned int)k.mark_.padw << 3);
+    else
+        h = ( (xpost_object_get_type(k)
+                | (k.comp_.tag & XPOST_OBJECT_TAG_DATA_FLAG_BANK))
+                << 1) /* ignore flags (except BANK!) */
+            + (k.comp_.sz << 3)
+            /* get_ent is -1 for a non-composite key; shift it as unsigned
+               so the mix is defined (same bits, no signed-shift UB) */
+            + ((unsigned int)xpost_object_get_ent(k) << 7)
+            + (k.comp_.off << 5);
     /* h = xpost_object_get_type(k); /\* test collisions. *\/ */
 #ifdef DEBUGDIC
     printf("\nhash(");
@@ -379,9 +390,13 @@ int dicgrow(Xpost_Context *ctx,
     xpost_memory_table_get_addr(mem, xpost_object_get_ent(d), &ad);
     dp = (void *)(mem->base + ad);
     sz = DICTABN(dp->sz);
-    tp = (void *)(mem->base + ad + sizeof(dichead)); /* copy data */
     for (i = 0; i < sz; i++)
     {
+        /* xpost_dict_put_memory below can grow -- and so relocate -- the
+           memory file, which leaves a table pointer cached across the call
+           dangling. Re-derive it from the current base each iteration; ad,
+           the source dict's own offset, does not move. */
+        tp = (void *)(mem->base + ad + sizeof(dichead));
         if (xpost_object_get_type(tp[i].key) != nulltype)
         {
             xpost_dict_put_memory(ctx, mem, n, tp[i].key, tp[i].value);

--- a/src/lib/xpost_dict.h
+++ b/src/lib/xpost_dict.h
@@ -122,6 +122,11 @@ unsigned xpost_dict_length_memory(/*@dependent@*/ Xpost_Memory_File *mem, Xpost_
 unsigned xpost_dict_max_length_memory(/*@dependent@*/ Xpost_Memory_File *mem, Xpost_Object d);
 
 /**
+ * @brief the nominal capacity the dict was requested with (for maxlength)
+ */
+unsigned xpost_dict_requested_length_memory(/*@dependent@*/ Xpost_Memory_File *mem, Xpost_Object d);
+
+/**
    investigate if size == maximum size.
  */
 int xpost_dict_is_full_memory(/*@dependent@*/ Xpost_Memory_File *mem, Xpost_Object d);

--- a/src/lib/xpost_file.c
+++ b/src/lib/xpost_file.c
@@ -650,6 +650,8 @@ int xpost_file_open(Xpost_Memory_File *mem,
             return invalidfileaccess;
         }
         f = xpost_file_cons(mem, stderr);
+        f.tag &= ~XPOST_OBJECT_TAG_DATA_FLAG_ACCESS_MASK;
+        f.tag |= (XPOST_OBJECT_TAG_ACCESS_FILE_WRITE << XPOST_OBJECT_TAG_DATA_FLAG_ACCESS_OFFSET);
     }
     else if (strcmp(fn, "%lineedit") == 0)
     {

--- a/src/lib/xpost_file.c
+++ b/src/lib/xpost_file.c
@@ -525,7 +525,9 @@ int statementedit(FILE *in, FILE **out)
 {
     FILE *fp;
     int c;
-    char nest[MAXNEST] = {0}; /* any of {(< waiting for matching >)} */
+    char nest[MAXNEST + 1] = {0}; /* any of {(< waiting for matching >)};
+                                     one past MAXNEST holds the level that
+                                     tips over the limit until it is rejected */
     int defer = -1; /* defer is a flag (-1 == false)
                        and an index into nest[] */
 
@@ -547,7 +549,7 @@ int statementedit(FILE *in, FILE **out)
     {
         if (defer > -1)
         {
-            if (defer > MAXNEST)
+            if (defer >= MAXNEST)
             {
                 return syntaxerror;
             }

--- a/src/lib/xpost_file.c
+++ b/src/lib/xpost_file.c
@@ -802,8 +802,19 @@ int xpost_file_get_bytes_available(Xpost_Memory_File *mem,
     FILE *fp;
     struct stat sb;
     long sz, pos;
+    Xpost_File *file;
 
-    fp = ((Xpost_DiskFile*)xpost_file_get_file_pointer(mem, f))->file;
+    file = xpost_file_get_file_pointer(mem, f);
+    if (!file) return ioerror;
+    /* only a seekable disk file has a determinable byte count; for a memory
+       file or a filter it cannot be determined, so report -1 (PLRM) rather
+       than reading a FILE* field the other file types do not have */
+    if (file->methods != &disk_methods)
+    {
+        *retval = -1;
+        return 0;
+    }
+    fp = ((Xpost_DiskFile*)file)->file;
     if (!fp) return ioerror;
     ret = fstat(fileno(fp), &sb);
     if (ret != 0)

--- a/src/lib/xpost_file.c
+++ b/src/lib/xpost_file.c
@@ -56,6 +56,25 @@
 #include "xpost_error.h"  /* file functions may throw errors */
 #include "xpost_file.h"  /* double-check prototypes */
 
+/* Report on a named regular file for the string form of status. Returns 1 and
+   fills the fields when the file exists, 0 otherwise. bytes is the size; pages
+   is an implementation-defined block count; referred and created are the
+   access and modification times in seconds. */
+int
+xpost_diskfile_stat(const char *path, long *pages, long *bytes,
+                    long *referred, long *created)
+{
+    struct stat st;
+
+    if (stat(path, &st) != 0 || !S_ISREG(st.st_mode))
+        return 0;
+    *bytes = (long)st.st_size;
+    *pages = (long)((st.st_size + 1023) / 1024);
+    *referred = (long)st.st_atime;
+    *created = (long)st.st_mtime;
+    return 1;
+}
+
 #ifdef _WIN32
 /*
  * FIXME: maybe use a WIN32 API for all this. See FIXME in xpost_op_file.c

--- a/src/lib/xpost_file.c
+++ b/src/lib/xpost_file.c
@@ -680,7 +680,25 @@ int xpost_file_open(Xpost_Memory_File *mem,
 #ifdef DEBUG_FILE
         printf("fopen\n");
 #endif
-        fp = fopen(fn, mode);
+        /* PostScript files are binary byte streams; force binary mode so that
+           Windows text translation -- CRLF rewriting and a 0x1A byte read as
+           end-of-file -- cannot corrupt or truncate them. On POSIX 'b' is a
+           no-op. The caller's mode string stays as given: the access
+           attributes below match against it. */
+        {
+            char bmode[8];
+            const char *fmode = mode;
+            size_t n = strlen(mode);
+
+            if (!strchr(mode, 'b') && n + 1 < sizeof bmode)
+            {
+                memcpy(bmode, mode, n);
+                bmode[n] = 'b';
+                bmode[n + 1] = '\0';
+                fmode = bmode;
+            }
+            fp = fopen(fn, fmode);
+        }
         if (fp == NULL)
         {
             switch (errno)

--- a/src/lib/xpost_file.h
+++ b/src/lib/xpost_file.h
@@ -210,4 +210,7 @@ int xpost_file_write_byte(Xpost_Memory_File *mem, Xpost_Object f, Xpost_Object b
  * @}
  */
 
+
+int xpost_diskfile_stat(const char *path, long *pages, long *bytes, long *referred, long *created);
+
 #endif

--- a/src/lib/xpost_font.c
+++ b/src/lib/xpost_font.c
@@ -34,6 +34,8 @@
 #endif
 
 #include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
 
 #ifdef HAVE_FONTCONFIG
 # include <fontconfig/fontconfig.h>
@@ -104,34 +106,135 @@ xpost_font_quit(void)
 }
 
 #ifdef HAVE_FREETYPE2
-static char *
-_xpost_font_face_filename_and_index_get(const char *name, int *idx)
-{
 # ifdef HAVE_FONTCONFIG
+/* case- and blank-insensitive name comparison, as fontconfig applies
+   to family names */
+static int
+_fc_name_eq(const char *a, const char *b)
+{
+    while (*a || *b)
+    {
+        while (*a == ' ') a++;
+        while (*b == ' ') b++;
+        if (tolower((unsigned char)*a) != tolower((unsigned char)*b))
+            return 0;
+        if (*a) a++;
+        if (*b) b++;
+    }
+    return 1;
+}
+
+/* does the matched font actually carry the requested name (as family
+   or PostScript name)? A fuzzy fontconfig match always returns some
+   face, so this distinguishes a real hit from a fallback. */
+static int
+_fc_match_is_exact(FcPattern *match, const char *name)
+{
+    char *s;
+    int i;
+
+    for (i = 0; FcPatternGetString(match, FC_FAMILY, i, (FcChar8 **)&s) == FcResultMatch; i++)
+        if (_fc_name_eq(s, name))
+            return 1;
+    for (i = 0; FcPatternGetString(match, FC_POSTSCRIPT_NAME, i, (FcChar8 **)&s) == FcResultMatch; i++)
+        if (_fc_name_eq(s, name))
+            return 1;
+    return 0;
+}
+
+/* PostScript style-variant suffixes translated to fontconfig style
+   flags, so that e.g. Helvetica-Bold reaches the bold face of the
+   family Helvetica is aliased to */
+static const struct { const char *suffix; const char *flags; } _ps_style_suffix[] = {
+    { "-BoldItalic",  ":bold:italic" },
+    { "-BoldOblique", ":bold:italic" },
+    { "-Bold",        ":bold" },
+    { "-Italic",      ":italic" },
+    { "-Oblique",     ":italic" },
+    { "-Roman",       "" },
+    { "-Regular",     "" },
+};
+
+static FcPattern *
+_fc_match_name(const char *name)
+{
     FcPattern *pattern;
     FcPattern *match;
-    char *file;
-    char *filename;
     FcResult result;
-
-    /* FIXME: parse name first ? */
 
     pattern = FcNameParse((const FcChar8 *)name);
     if (!pattern)
         return NULL;
 
     if (!FcConfigSubstitute (_xpost_font_fc_config, pattern, FcMatchPattern))
-        goto destroy_pattern;
+    {
+        FcPatternDestroy(pattern);
+        return NULL;
+    }
 
     FcDefaultSubstitute(pattern);
     match = FcFontMatch(_xpost_font_fc_config, pattern, &result);
-    //if (result != FcResultMatch) goto destroy_pattern;
+    FcPatternDestroy(pattern);
     switch (result) {
         case FcResultMatch: break;
-        case FcResultNoMatch: goto destroy_pattern;
+        case FcResultNoMatch: goto destroy_match;
         case FcResultTypeMismatch: break;
         case FcResultNoId: break;
-        case FcResultOutOfMemory: goto destroy_pattern;
+        case FcResultOutOfMemory: goto destroy_match;
+    }
+    return match;
+
+  destroy_match:
+    if (match)
+        FcPatternDestroy(match);
+    return NULL;
+}
+# endif
+
+static char *
+_xpost_font_face_filename_and_index_get(const char *name, int *idx)
+{
+# ifdef HAVE_FONTCONFIG
+    FcPattern *match;
+    char *file;
+    char *filename;
+    FcResult result;
+
+    match = _fc_match_name(name);
+    if (!match)
+        return NULL;
+
+    /* a fallback match for a PostScript style-variant name loses the
+       style (fontconfig reads the whole name as a family); requery as
+       family plus style flags so the alias family's styled face wins */
+    if (!_fc_match_is_exact(match, name))
+    {
+        size_t i;
+
+        for (i = 0; i < sizeof(_ps_style_suffix)/sizeof(*_ps_style_suffix); i++)
+        {
+            const char *sfx = _ps_style_suffix[i].suffix;
+            size_t nlen = strlen(name), slen = strlen(sfx);
+
+            if (nlen > slen && strcmp(name + nlen - slen, sfx) == 0)
+            {
+                char *styled = malloc(nlen + strlen(_ps_style_suffix[i].flags) + 1);
+                FcPattern *restyled;
+
+                if (!styled)
+                    break;
+                memcpy(styled, name, nlen - slen);
+                strcpy(styled + nlen - slen, _ps_style_suffix[i].flags);
+                restyled = _fc_match_name(styled);
+                free(styled);
+                if (restyled)
+                {
+                    FcPatternDestroy(match);
+                    match = restyled;
+                }
+                break;
+            }
+        }
     }
 
     result = FcPatternGetString(match, FC_FILE, 0, (FcChar8 **)&file);
@@ -149,14 +252,11 @@ _xpost_font_face_filename_and_index_get(const char *name, int *idx)
     filename = strdup(file);
 
     FcPatternDestroy(match);
-    FcPatternDestroy(pattern);
 
     return filename;
 
   destroy_match:
     FcPatternDestroy(match);
-  destroy_pattern:
-    FcPatternDestroy(pattern);
 # endif
 
     return NULL;

--- a/src/lib/xpost_font.c
+++ b/src/lib/xpost_font.c
@@ -231,7 +231,7 @@ void
 xpost_font_face_scale(void *face, real scale)
 {
 #ifdef HAVE_FREETYPE2
-    FT_Set_Char_Size((FT_Face)face, 0, (FT_F26Dot6)(scale * 64), 96, 96);
+    FT_Set_Char_Size((FT_Face)face, 0, (FT_F26Dot6)(scale * 64), 72, 72);
 #else
     (void)face;
     (void)scale;

--- a/src/lib/xpost_font.c
+++ b/src/lib/xpost_font.c
@@ -381,7 +381,9 @@ unsigned int
 xpost_font_face_glyph_index_get(void *face, char c)
 {
 #ifdef HAVE_FREETYPE2
-    return FT_Get_Char_Index(face, c);
+    /* the character code is a byte value: keep 128-255 out of the
+       sign extension */
+    return FT_Get_Char_Index(face, (unsigned char)c);
 #else
     (void)face;
     (void)c;
@@ -480,45 +482,4 @@ xpost_font_face_glyph_buffer_get(void *face, unsigned char **buffer, int *rows, 
 #endif
 }
 
-int
-xpost_font_face_kerning_has(void *face)
-{
-#ifdef HAVE_FREETYPE2
-    if (!FT_HAS_KERNING(((FT_Face)face)))
-        return 1;
 
-    XPOST_LOG_INFO("Face has no kerning information");
-#else
-    (void)face;
-#endif
-
-    return 0;
-}
-
-int
-xpost_font_face_kerning_delta_get(void *face, unsigned int glyph_previous, unsigned int glyph_index, long *delta_x, long *delta_y)
-{
-#ifdef HAVE_FREETYPE2
-    FT_Vector delta;
-    FT_Error err;
-
-    err = FT_Get_Kerning((FT_Face)face, glyph_previous, glyph_index,
-                         FT_KERNING_DEFAULT, &delta);
-    if (!err)
-    {
-        *delta_x = delta.x;
-        *delta_y = delta.y;
-        return 1;
-    }
-
-    XPOST_LOG_INFO("Can not retrieve kerning (error : %d)", err);
-#else
-    (void)face;
-    (void)glyph_previous;
-    (void)glyph_index;
-    (void)delta_x;
-    (void)delta_y;
-#endif
-
-    return 0;
-}

--- a/src/lib/xpost_font.c
+++ b/src/lib/xpost_font.c
@@ -331,7 +331,27 @@ void
 xpost_font_face_scale(void *face, real scale)
 {
 #ifdef HAVE_FREETYPE2
-    FT_Set_Char_Size((FT_Face)face, 0, (FT_F26Dot6)(scale * 64), 72, 72);
+    FT_Face f = face;
+
+    /* Request the scale directly (16.16 pixels per font unit) rather
+       than a nominal character size: a nominal request quantizes the
+       em to 1/64 pixel, which at the sub-pixel em sizes produced by a
+       small user-space size under a modest CTM is a metrics error of
+       whole percents. Fixed-size faces reject a scale request; they
+       keep the nominal path. */
+    if (f->units_per_EM > 0)
+    {
+        FT_Size_RequestRec req;
+
+        req.type = FT_SIZE_REQUEST_TYPE_SCALES;
+        req.width = req.height =
+            (FT_Long)(scale * 64.0 * 65536.0 / f->units_per_EM + 0.5);
+        req.horiResolution = 0;
+        req.vertResolution = 0;
+        if (FT_Request_Size(f, &req) == 0)
+            return;
+    }
+    FT_Set_Char_Size(f, 0, (FT_F26Dot6)(scale * 64 + 0.5), 72, 72);
 #else
     (void)face;
     (void)scale;
@@ -406,6 +426,34 @@ xpost_font_face_glyph_render(void *face, unsigned int glyph_index)
     return 0;
 }
 
+#ifdef HAVE_FREETYPE2
+/* The hinter rounds slot->advance to whole pixels and the rounding
+   accumulates as horizontal drift across a string. Derive the pen
+   advance from the unhinted linear width instead, applied through the
+   face's current transform (identity when none is set), and report it
+   in 16.16 pixels: squeezing through the slot's 26.6 resolution costs
+   up to 1/64 pixel per glyph, a whole percent of a sub-pixel em.
+   Bitmap-only glyphs carry no linear width; those widen the slot
+   advance. */
+static void
+_glyph_linear_advance(FT_Face face, long *advance_x, long *advance_y)
+{
+    FT_GlyphSlot slot = face->glyph;
+    FT_Fixed lin = slot->linearHoriAdvance;   /* 16.16 pixels */
+    FT_Matrix m;
+
+    if (lin == 0)
+    {
+        *advance_x = slot->advance.x << 10;   /* 26.6 -> 16.16 */
+        *advance_y = slot->advance.y << 10;
+        return;
+    }
+    FT_Get_Transform(face, &m, NULL);
+    *advance_x = FT_MulFix(m.xx, lin);
+    *advance_y = FT_MulFix(m.yx, lin);
+}
+#endif
+
 void
 xpost_font_face_glyph_buffer_get(void *face, unsigned char **buffer, int *rows, int *width, int *pitch, char *pixel_mode, int *left, int *top, long *advance_x, long *advance_y)
 {
@@ -417,8 +465,7 @@ xpost_font_face_glyph_buffer_get(void *face, unsigned char **buffer, int *rows, 
     *pixel_mode = ((FT_Face)face)->glyph->bitmap.pixel_mode;
     *left = ((FT_Face)face)->glyph->bitmap_left;
     *top = ((FT_Face)face)->glyph->bitmap_top;
-    *advance_x = ((FT_Face)face)->glyph->advance.x;
-    *advance_y = ((FT_Face)face)->glyph->advance.y;
+    _glyph_linear_advance((FT_Face)face, advance_x, advance_y);
 #else
     (void)face;
     (void)buffer;

--- a/src/lib/xpost_font.h
+++ b/src/lib/xpost_font.h
@@ -170,35 +170,5 @@ int xpost_font_face_glyph_render(void *face, unsigned int glyph_index);
 
 void xpost_font_face_glyph_buffer_get(void *face, unsigned char **buffer, int *rows, int *width, int *pitch, char *pixel_mode, int *left, int *top, long *advance_x, long *advance_y);
 
-/**
- * @brief Check if the given font has kerning feature.
- *
- * @param[in] face The font face.
- * @return 1 if the font has kerning feature, 0 otherwise.
- *
- * This function checks if @p face has kerning feature. It returns 1
- * if so, 0 otherwise.
- *
- * @see xpost_font_face_kerning_delta_get()
- */
-int xpost_font_face_kerning_has(void *face);
-
-/**
- * @brief Retrieve the kerning vector of the given glyph.
- *
- * @param[in] face The font face.
- * @param[in] glyph_previous The previous glyph.
- * @param[in] glyph_index The current glyph.
- * @param[out] delta_x The horizontal component of the kerning vector.
- * @param[out] delta_y The vertical component of the kerning vector.
- * @return 1 on success, 0 otherwise.
- *
- * This function stores the kerning vector of the glyph
- * @p glyph_index computed from @p glyph_previous  (in font @p face)
- * in @p delta_x and @p delta_y. It returns 1 on success, 0 otherwise.
- *
- * @see xpost_font_face_kerning_has()
- */
-int xpost_font_face_kerning_delta_get(void *face, unsigned int glyph_previous, unsigned int glyph_index, long *delta_x, long *delta_y);
 
 #endif

--- a/src/lib/xpost_free.c
+++ b/src/lib/xpost_free.c
@@ -250,7 +250,6 @@ int xpost_free_alloc(Xpost_Memory_File *mem,
     if (!mem->interpreter_get_initializing())
     {
 #ifdef XPOST_USE_THRESHOLD
-        //(void)period;
         if ((mem->threshold -= sz) <= 0)
         {
             mem->threshold = XPOST_GARBAGE_COLLECTION_THRESHOLD;
@@ -303,8 +302,11 @@ int xpost_free_alloc(Xpost_Memory_File *mem,
             unsigned int ent;
             unsigned int ad;
 
-            /* if this ent is too big */
-            if (tsz * XPOST_FREE_ACCEPT_DENOM > sz * XPOST_FREE_ACCEPT_OVERSIZE)
+            /* if this ent is too big. a small absolute amount of waste
+               is always acceptable: rejecting all reuse for small
+               allocations grows the entity table without bound */
+            if (tsz - sz > 32 &&
+                tsz * XPOST_FREE_ACCEPT_DENOM > sz * XPOST_FREE_ACCEPT_OVERSIZE)
             {
                 return 0; /* early exit to _new allocator since free list is sorted */
             }

--- a/src/lib/xpost_free.c
+++ b/src/lib/xpost_free.c
@@ -293,11 +293,19 @@ int xpost_free_alloc(Xpost_Memory_File *mem,
     while (e) /* e is not zero */
     {
         unsigned int tsz;
-        if (e > XPOST_OBJECT_COMP_MAX_ENT)
+        /* The links live inside the freed entities' data, where a stale
+           write can turn one into an arbitrary number. Handing out an
+           entity that is not actually free aliases two owners onto one
+           allocation, so validate every node: freed entities carry a
+           zero tag. On any inconsistency discard the list and request
+           a collection to rebuild it. */
+        if (e > XPOST_OBJECT_COMP_MAX_ENT ||
+            e >= mem->table.nextent ||
+            mem->table.tab[e].tag != 0)
         {
             unsigned int zero = 0;
-            XPOST_LOG_ERR("ent number %u exceeds object storage max %u",
-                    e, XPOST_OBJECT_COMP_MAX_ENT);
+            XPOST_LOG_ERR("free list corrupt at ent %u (tag %u): discarding",
+                    e, e < mem->table.nextent ? mem->table.tab[e].tag : 0);
             /* bad element found: discard free list */
             xpost_memory_put(mem, 0, 0, sizeof zero, &zero);
             return 2; /* request collection to fill the list */

--- a/src/lib/xpost_free.c
+++ b/src/lib/xpost_free.c
@@ -47,6 +47,21 @@
    initialize the free-list in the memory file.
    free list head is in slot zero
    sz is 0 so gc will ignore it */
+/* collection threshold in allocated bytes; overridable for testing
+   and for embedders that want more frequent collections */
+static int _xpost_free_gc_threshold(void)
+{
+    static int v = -1;
+    if (v < 0)
+    {
+        const char *e = getenv("XPOST_GC_THRESHOLD");
+        v = e ? atoi(e) : 0;
+        if (v <= 0)
+            v = XPOST_GARBAGE_COLLECTION_THRESHOLD;
+    }
+    return v;
+}
+
 int xpost_free_init(Xpost_Memory_File *mem)
 {
     unsigned int ent;
@@ -83,7 +98,7 @@ int xpost_free_init(Xpost_Memory_File *mem)
     /* make free list available for general memory allocations */
     (void) xpost_memory_register_free_list_alloc_function(mem, xpost_free_alloc);
     mem->period = XPOST_GARBAGE_COLLECTION_PERIOD;
-    mem->threshold = XPOST_GARBAGE_COLLECTION_THRESHOLD;
+    mem->threshold = _xpost_free_gc_threshold();
 
     return 1;
 }
@@ -252,7 +267,7 @@ int xpost_free_alloc(Xpost_Memory_File *mem,
 #ifdef XPOST_USE_THRESHOLD
         if ((mem->threshold -= sz) <= 0)
         {
-            mem->threshold = XPOST_GARBAGE_COLLECTION_THRESHOLD;
+            mem->threshold = _xpost_free_gc_threshold();
             return 2;
         }
 #else

--- a/src/lib/xpost_garbage.c
+++ b/src/lib/xpost_garbage.c
@@ -295,15 +295,14 @@ int _xpost_garbage_mark_object(Xpost_Context *ctx,
                     XPOST_LOG_ERR("cannot retrieve tag for array ent %u", ent);
                     return 0;
                 }
-                if (o.comp_.sz != objmem->table.tab[ent].used/sizeof(Xpost_Object))
-                {
-                    XPOST_LOG_INFO("o.comp_.sz %u != tab[ent].used/obj %u",
-                            o.comp_.sz, objmem->table.tab[ent].used/sizeof(Xpost_Object));
-                }
+                /* subarray views share the entity: descend over the whole
+                   underlying allocation, not the view window, so elements
+                   reachable only through another view stay marked (the
+                   ent-level marked flag makes the first view visited the
+                   only one descended) */
                 if (!_xpost_garbage_mark_array(ctx, objmem, ad,
-                            //mem->table.tab[ent].used/sizeof(Xpost_Object)
-                            o.comp_.sz
-                            , markall))
+                            objmem->table.tab[ent].used/sizeof(Xpost_Object),
+                            markall))
                     return 0;
             }
             break;

--- a/src/lib/xpost_garbage.c
+++ b/src/lib/xpost_garbage.c
@@ -424,7 +424,7 @@ next:
         if (i == XPOST_STACK_SEGMENT_SIZE) /* ie. s->top == XPOST_STACK_SEGMENT_SIZE */
         {
             if (s->nextseg == 0)
-                return 0;
+                return 1; /* final segment exactly full: walk complete */
             s = (Xpost_Stack *)(mem->base + s->nextseg);
             start = 0;
             goto next;
@@ -464,7 +464,7 @@ next:
         if (i == XPOST_STACK_SEGMENT_SIZE) /* ie. s->top == XPOST_STACK_SEGMENT_SIZE */
         {
             if (s->nextseg == 0)
-                return 0;
+                return 1; /* final segment exactly full: walk complete */
             s = (Xpost_Stack *)(mem->base + s->nextseg);
             goto next;
         }
@@ -555,6 +555,8 @@ next:
         }
         if (i == XPOST_STACK_SEGMENT_SIZE) /* ie. s->top == XPOST_STACK_SEGMENT_SIZE */
         {
+            if (s->nextseg == 0)
+                return 1; /* final segment exactly full: walk complete */
             s = (Xpost_Stack *)(mem->base + s->nextseg);
             goto next;
         }
@@ -588,6 +590,8 @@ int _xpost_garbage_mark_save(Xpost_Context *ctx,
         }
         if (i == XPOST_STACK_SEGMENT_SIZE) /* ie. s->top == XPOST_STACK_SEGMENT_SIZE */
         {
+            if (s->nextseg == 0)
+                return 1; /* final segment exactly full: walk complete */
             s = (void *)(mem->base + s->nextseg);
             goto next;
         }
@@ -649,6 +653,7 @@ unsigned int _xpost_garbage_sweep(Xpost_Memory_File *mem)
 
     return sz;
 }
+
 
 /*
    determine GLOBAL/LOCAL

--- a/src/lib/xpost_garbage.c
+++ b/src/lib/xpost_garbage.c
@@ -798,6 +798,10 @@ int xpost_garbage_collect(Xpost_Memory_File *mem, int dosweep, int markall)
 #endif
             if (!_xpost_garbage_mark_object(ctx, mem, ctx->window_device, markall))
                 return -1;
+
+            /* the object being executed may exist only here */
+            if (!_xpost_garbage_mark_object(ctx, mem, ctx->currentobject, markall))
+                return -1;
 #if 0
 #ifdef DEBUG_GC
             printf("marking event handler\n");
@@ -826,7 +830,7 @@ int xpost_garbage_collect(Xpost_Memory_File *mem, int dosweep, int markall)
         }
     }
 
-    printf("collect recovered %u bytes\n", sz);
+    XPOST_LOG_INFO("collect recovered %u bytes", sz);
     return sz;
 }
 

--- a/src/lib/xpost_garbage.c
+++ b/src/lib/xpost_garbage.c
@@ -262,6 +262,7 @@ int _xpost_garbage_mark_object(Xpost_Context *ctx,
             }
 
             objmem = xpost_context_select_memory(ctx, o);
+            if (!objmem) return 0;
             if (objmem != mem) {
                 if (!markall)
                     break;
@@ -273,7 +274,6 @@ int _xpost_garbage_mark_object(Xpost_Context *ctx,
                         ent);
                 return 0;
             }
-            if (!objmem) return 0;
             if (!_xpost_garbage_ent_is_marked(objmem, ent, &ret))
                 return 0;
             if (!ret) {

--- a/src/lib/xpost_garbage.c
+++ b/src/lib/xpost_garbage.c
@@ -614,6 +614,12 @@ unsigned int _xpost_garbage_sweep(Xpost_Memory_File *mem)
     unsigned int sz = 0;
     int ret;
 
+    /* diagnostic quarantine: sweep nothing, so freed entities are never
+       reused; distinguishes stale-holder-of-recycled-entity bugs (which
+       vanish) from in-place corruption (which persists) */
+    if (getenv("XPOST_GC_NO_REUSE"))
+        return 0;
+
     ret = xpost_memory_table_get_addr(mem, XPOST_MEMORY_TABLE_SPECIAL_FREE, &z); /* address of the free list head */
     if (!ret)
     {
@@ -654,6 +660,144 @@ unsigned int _xpost_garbage_sweep(Xpost_Memory_File *mem)
     return sz;
 }
 
+
+/* P0 diagnostic: independent reachability verifier. BFS from the same
+   roots with a private visited set and unconditional full descent;
+   report any reachable entity whose mark bit is clear, with its parent. */
+typedef struct { unsigned int ent; int bank; unsigned int parent; int pbank; } _vq_item;
+static _vq_item *_vq; static unsigned int _vq_n, _vq_cap;
+static unsigned char *_vseen_lo, *_vseen_gl; static unsigned int _vseen_lo_n, _vseen_gl_n;
+
+static void _verify_push(Xpost_Context *ctx, Xpost_Object o,
+                         unsigned int parent, int pbank)
+{
+    unsigned int ent; int bank;
+    Xpost_Memory_File *m;
+    unsigned char *seen;
+    Xpost_Object_Type t = xpost_object_get_type(o);
+    if (t != arraytype && t != dicttype && t != stringtype && t != filetype)
+        return;
+    m = xpost_context_select_memory(ctx, o);
+    bank = (m == ctx->gl);
+    ent = (t == filetype) ? o.mark_.padw : (unsigned int)xpost_object_get_ent(o);
+    seen = bank ? _vseen_gl : _vseen_lo;
+    if (ent >= (bank ? _vseen_gl_n : _vseen_lo_n)) return;
+    if (seen[ent]) return;
+    seen[ent] = 1;
+    if (_vq_n == _vq_cap)
+    {
+        unsigned int newcap = _vq_cap ? _vq_cap * 2 : 65536;
+        _vq_item *tmp = realloc(_vq, newcap * sizeof *_vq);
+        if (!tmp)
+            return; /* keep the existing queue; the verify pass skips this node */
+        _vq = tmp;
+        _vq_cap = newcap;
+    }
+    _vq[_vq_n].ent = ent; _vq[_vq_n].bank = bank;
+    _vq[_vq_n].parent = parent; _vq[_vq_n].pbank = pbank;
+    _vq_n++;
+}
+
+static void _verify_stack(Xpost_Context *ctx, Xpost_Memory_File *mem,
+                          unsigned int stackadr)
+{
+    Xpost_Stack *s = (Xpost_Stack *)(mem->base + stackadr);
+    unsigned int i;
+    for (;;)
+    {
+        for (i = 0; i < s->top; i++)
+            _verify_push(ctx, s->data[i], 0xFFFFFFFF, 2);
+        if (s->top == XPOST_STACK_SEGMENT_SIZE && s->nextseg)
+            s = (Xpost_Stack *)(mem->base + s->nextseg);
+        else
+            break;
+    }
+}
+
+static void _verify_reachability(Xpost_Context *ctx, Xpost_Memory_File *mem)
+{
+    unsigned int head = 0;
+    int bad = 0;
+
+    (void)mem;
+    _vq_n = 0;
+    _vseen_lo_n = ctx->lo->table.nextent; _vseen_gl_n = ctx->gl->table.nextent;
+    _vseen_lo = calloc(_vseen_lo_n, 1); _vseen_gl = calloc(_vseen_gl_n, 1);
+
+    _verify_stack(ctx, ctx->lo, ctx->os);
+    _verify_stack(ctx, ctx->lo, ctx->ds);
+    _verify_stack(ctx, ctx->lo, ctx->es);
+    _verify_stack(ctx, ctx->lo, ctx->hold);
+    _verify_push(ctx, ctx->currentobject, 0xFFFFFFFF, 3);
+    _verify_push(ctx, ctx->window_device, 0xFFFFFFFF, 3);
+
+    while (head < _vq_n)
+    {
+        _vq_item it = _vq[head++];
+        Xpost_Memory_File *m = it.bank ? ctx->gl : ctx->lo;
+        unsigned int tag = m->table.tab[it.ent].tag;
+        unsigned int used = m->table.tab[it.ent].used;
+        unsigned int adr = m->table.tab[it.ent].adr;
+        unsigned int off;
+
+        /* local unmarked reachable = the gap (global is never swept) */
+        if (!it.bank && it.ent >= ctx->lo->start &&
+            (ctx->lo->table.tab[it.ent].mark & XPOST_MEMORY_TABLE_MARK_DATA_MARK_MASK) == 0
+            && ctx->lo->table.tab[it.ent].sz != 0 && tag != filetype)
+        {
+            fprintf(stderr, "VERIFY GAP: lo ent %u (tag %u used %u) reachable "
+                    "via parent ent %u (bank %d)\n",
+                    it.ent, tag, used, it.parent, it.pbank);
+            bad++;
+            if (bad > 8) break;
+        }
+        if (tag == arraytype)
+        {
+            for (off = 0; off + sizeof(Xpost_Object) <= used; off += sizeof(Xpost_Object))
+            {
+                Xpost_Object o;
+                memcpy(&o, m->base + adr + off, sizeof o);
+                _verify_push(ctx, o, it.ent, it.bank);
+            }
+        }
+        else if (tag == dicttype)
+        {
+            dichead *dp = (void *)(m->base + adr);
+            dicrec *tp = (void *)(m->base + adr + sizeof(dichead));
+            int j;
+            for (j = 0; j < DICTABN(dp->sz); j++)
+            {
+                if (xpost_object_get_type(tp[j].key) != nulltype)
+                {
+                    _verify_push(ctx, tp[j].key, it.ent, it.bank);
+                    _verify_push(ctx, tp[j].value, it.ent, it.bank);
+                }
+            }
+        }
+    }
+    if (bad)
+        fprintf(stderr, "VERIFY: %d gaps found (%u reachable ents)\n", bad, _vq_n);
+    if (getenv("XPOST_GC_CENSUS"))
+    {
+        unsigned int i2, cnt_lo = 0, cnt_gl = 0;
+        unsigned long bytes_lo = 0, bytes_gl = 0;
+        unsigned int bytag[32] = {0};
+        for (i2 = 0; i2 < _vq_n; i2++)
+        {
+            Xpost_Memory_File *m2 = _vq[i2].bank ? ctx->gl : ctx->lo;
+            unsigned int t2 = m2->table.tab[_vq[i2].ent].tag;
+            if (_vq[i2].bank) { cnt_gl++; bytes_gl += m2->table.tab[_vq[i2].ent].sz; }
+            else { cnt_lo++; bytes_lo += m2->table.tab[_vq[i2].ent].sz; }
+            if (t2 < 32) bytag[t2]++;
+        }
+        fprintf(stderr, "CENSUS: lo %u ents %lu bytes | gl %u ents %lu bytes |"
+                " arr %u dict %u str %u | lo_nextent %u\n",
+                cnt_lo, bytes_lo, cnt_gl, bytes_gl,
+                bytag[5], bytag[6], bytag[16], ctx->lo->table.nextent);
+    }
+    free(_vseen_lo); free(_vseen_gl);
+    _vseen_lo = _vseen_gl = NULL;
+}
 
 /*
    determine GLOBAL/LOCAL
@@ -820,6 +964,57 @@ int xpost_garbage_collect(Xpost_Memory_File *mem, int dosweep, int markall)
 #ifdef DEBUG_GC
         printf("sweep\n");
 #endif
+        if (!isglobal && getenv("XPOST_GC_VERIFY") && ctx)
+            _verify_reachability(ctx, mem);
+        /* P0 diagnostic: before sweeping local VM, report any global
+           container still referencing an unmarked (about-to-die) local
+           entity -- the cross-bank reference the local mark cannot see */
+        if (!isglobal && getenv("XPOST_GC_XBANK_CHECK") && ctx && ctx->gl)
+        {
+            unsigned int ge, off;
+            Xpost_Memory_File *gl = ctx->gl;
+            for (ge = gl->start; ge < gl->table.nextent; ge++)
+            {
+                unsigned int gtag = gl->table.tab[ge].tag;
+                unsigned int gused = gl->table.tab[ge].used;
+                unsigned int gadr = gl->table.tab[ge].adr;
+                if (gtag != arraytype && gtag != dicttype) continue;
+                for (off = 0; off + sizeof(Xpost_Object) <= gused; off += sizeof(Xpost_Object))
+                {
+                    Xpost_Object o;
+                    unsigned int te;
+                    memcpy(&o, gl->base + gadr + off, sizeof o);
+                    if (!xpost_object_is_composite(o)) continue;
+                    if (o.tag & XPOST_OBJECT_TAG_DATA_FLAG_BANK) continue; /* global ref: fine */
+                    te = xpost_object_get_ent(o);
+                    if (te >= mem->table.nextent) continue;
+                    if ((mem->table.tab[te].mark & XPOST_MEMORY_TABLE_MARK_DATA_MARK_MASK) == 0
+                        && mem->table.tab[te].sz != 0)
+                    {
+                        fprintf(stderr, "XBANK: gl ent %u (tag %u, %s) slot %u -> dying lo ent %u "
+                                "(type %u sz %u)",
+                                ge, gtag,
+                                (gl->table.tab[ge].mark & XPOST_MEMORY_TABLE_MARK_DATA_MARK_MASK)
+                                    ? "MARKED" : "unmarked",
+                                (unsigned int)(off / sizeof(Xpost_Object)),
+                                te, xpost_object_get_type(o), o.comp_.sz);
+                        if (xpost_object_get_type(o) == stringtype && o.comp_.sz < 200)
+                        {
+                            unsigned int k;
+                            fprintf(stderr, " content=\"");
+                            for (k = 0; k < o.comp_.sz; k++)
+                            {
+                                unsigned char c = gl->base[0]; /* placeholder */
+                                c = *(mem->base + mem->table.tab[te].adr + o.comp_.off + k);
+                                fprintf(stderr, "%c", (c >= 32 && c < 127) ? c : '.');
+                            }
+                            fprintf(stderr, "\"");
+                        }
+                        fprintf(stderr, "\n");
+                    }
+                }
+            }
+        }
         sz += _xpost_garbage_sweep(mem);
         if (isglobal)
         {

--- a/src/lib/xpost_garbage.c
+++ b/src/lib/xpost_garbage.c
@@ -495,58 +495,64 @@ int _xpost_garbage_mark_save_stack(Xpost_Context *ctx,
 next:
         for (i = 0; i < s->top; i++)
         {
+            /* saverec entity numbers may exceed a word; decode their full
+               value and type through the accessors (see xpost_save.h)
+               rather than reading the packed fields raw. */
+            unsigned int rsrc = XPOST_SAVEREC_SRC(s->data[i]);
+            unsigned int rcpy = XPOST_SAVEREC_CPY(s->data[i]);
+            unsigned int rtype = XPOST_SAVEREC_TYPE(s->data[i]);
             /* _xpost_garbage_mark_object(ctx, mem, s->data[i]); */
             /* _xpost_garbage_mark_save_stack(ctx, mem, s->data[i].save_.stk); */
-            ret = _xpost_garbage_mark_ent(mem, s->data[i].saverec_.src);
+            ret = _xpost_garbage_mark_ent(mem, rsrc);
             if (!ret)
             {
                 XPOST_LOG_ERR("cannot mark array");
                 return 0;
             }
-            ret = _xpost_garbage_mark_ent(mem, s->data[i].saverec_.cpy);
+            ret = _xpost_garbage_mark_ent(mem, rcpy);
             if (!ret)
             {
                 XPOST_LOG_ERR("cannot mark array");
                 return 0;
             }
-            if (s->data[i].saverec_.tag == dicttype)
+            if (rtype == dicttype)
             {
-                ret = xpost_memory_table_get_addr(mem, s->data[i].saverec_.src, &ad);
+                ret = xpost_memory_table_get_addr(mem, rsrc, &ad);
                 if (!ret)
                 {
                     XPOST_LOG_ERR("cannot retrieve address for ent %u",
-                                  s->data[i].saverec_.src);
+                                  rsrc);
                     return 0;
                 }
                 if (!_xpost_garbage_mark_dict(ctx, mem, ad, 0))
                     return 0;
-                ret = xpost_memory_table_get_addr(mem, s->data[i].saverec_.cpy, &ad);
+                ret = xpost_memory_table_get_addr(mem, rcpy, &ad);
                 if (!ret)
                 {
                     XPOST_LOG_ERR("cannot retrieve address for ent %u",
-                                  s->data[i].saverec_.cpy);
+                                  rcpy);
                     return 0;
                 }
                 if (!_xpost_garbage_mark_dict(ctx, mem, ad, 0))
                     return 0;
             }
-            if (s->data[i].saverec_.tag == arraytype)
+            if (rtype == arraytype)
             {
                 unsigned int sz = s->data[i].saverec_.pad;
-                ret = xpost_memory_table_get_addr(mem, s->data[i].saverec_.src, &ad);
+                ret = xpost_memory_table_get_addr(mem, rsrc, &ad);
                 if (!ret)
                 {
                     XPOST_LOG_ERR("cannot retrieve address for array ent %u",
-                                  s->data[i].saverec_.src);
+                                  rsrc);
                     return 0;
                 }
                 if (!_xpost_garbage_mark_array(ctx, mem, ad, sz, 0))
                     return 0;
-                ret = xpost_memory_table_get_addr(mem, s->data[i].saverec_.cpy, &ad);
+                ret = xpost_memory_table_get_addr(mem, rcpy, &ad);
                 if (!ret)
                 {
                     XPOST_LOG_ERR("cannot retrieve address for array ent %u",
-                                  s->data[i].saverec_.cpy);
+                                  rcpy);
                     return 0;
                 }
                 if (!_xpost_garbage_mark_array(ctx, mem, ad, sz, 0))

--- a/src/lib/xpost_interpreter.c
+++ b/src/lib/xpost_interpreter.c
@@ -1044,9 +1044,10 @@ void loadinitps(Xpost_Context *ctx)
     if ((path = getenv("XPOST_DATA_DIR")))
         XPOST_PATH_INIT;
 
-    /* directory of the shared library */
-    path = (char *)xpost_data_dir_get(); /* always well-defined */
-    XPOST_PATH_INIT;
+    /* directory of the shared library (absent for an uninstalled build) */
+    path = (char *)xpost_data_dir_get();
+    if (path)
+        XPOST_PATH_INIT;
 
 #ifdef PACKAGE_DATA_DIR
     {

--- a/src/lib/xpost_interpreter.c
+++ b/src/lib/xpost_interpreter.c
@@ -809,6 +809,15 @@ ctxswitch:
 
     while(!ctx->quit)
     {
+        /* safe point: between evaluation steps every live object is
+           reachable from the stacks, so a requested collection cannot
+           sweep an operator's C-held intermediates */
+        if (ctx->lo->garbage_collect_pending)
+        {
+            ctx->lo->garbage_collect_pending = 0;
+            if (ctx->lo->garbage_collect_is_installed)
+                (void)ctx->lo->garbage_collect(ctx->lo, 1, 1);
+        }
         ret = eval(ctx);
         if (ret)
             switch (ret)

--- a/src/lib/xpost_interpreter.c
+++ b/src/lib/xpost_interpreter.c
@@ -34,7 +34,6 @@
 #endif
 
 #include <assert.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -938,6 +937,7 @@ void setlocalconfig(Xpost_Context *ctx,
     char *devstr;
     char *subdevice;
     char *dimensions;
+    char dimensions_buf[48]; /* holds "%d %d" for any int width/height */
 
     ctx->vmmode = GLOBAL;
 
@@ -961,8 +961,8 @@ void setlocalconfig(Xpost_Context *ctx,
         }
     }
     if (set_size == XPOST_USE_SIZE){
-        dimensions = malloc(2 + (int)ceil(log10(width)) + (int)ceil(log10(height)));
-        sprintf(dimensions, "%d %d", width, height);
+        snprintf(dimensions_buf, sizeof(dimensions_buf), "%d %d", width, height);
+        dimensions = dimensions_buf;
     } else {
         static char x[] = "612 792";
         dimensions = x;

--- a/src/lib/xpost_interpreter.c
+++ b/src/lib/xpost_interpreter.c
@@ -303,6 +303,56 @@ void xpost_interpreter_exit(Xpost_Interpreter *itpptr)
 typedef
 int evalfunc(Xpost_Context *ctx);
 
+/* The stacks grow by VM segments without any structural bound, so a
+   runaway loop or recursion would grind through memory rather than
+   fail. Execution past these depths raises the stack's overflow
+   error, checked in the interpreter loop where depth accumulates. A
+   latch per stack raises once per crossing, so the error machinery
+   runs (and the program recovers) above the ceiling without
+   retriggering it, and rearms when the depth recedes. The ceilings
+   sit far beyond any legitimate job's depth while keeping the error
+   path's walk over the stacks cheap. */
+#define XPOST_EXEC_STACK_LIMIT 1000000
+#define XPOST_OPER_STACK_LIMIT 1000000
+#define XPOST_DICT_STACK_LIMIT 5000
+
+/* raise a stack's overflow error on crossing its ceiling; 0 if every
+   stack is within bounds or already reported */
+static int _stack_ceilings(Xpost_Context *ctx)
+{
+    if (ctx->es_over == 0)
+    {
+        if (xpost_stack_count(ctx->lo, ctx->es) > XPOST_EXEC_STACK_LIMIT)
+        {
+            ctx->es_over = 1;
+            return execstackoverflow;
+        }
+    }
+    else if (xpost_stack_count(ctx->lo, ctx->es) <= XPOST_EXEC_STACK_LIMIT)
+        ctx->es_over = 0;
+    if (ctx->os_over == 0)
+    {
+        if (xpost_stack_count(ctx->lo, ctx->os) > XPOST_OPER_STACK_LIMIT)
+        {
+            ctx->os_over = 1;
+            return stackoverflow;
+        }
+    }
+    else if (xpost_stack_count(ctx->lo, ctx->os) <= XPOST_OPER_STACK_LIMIT)
+        ctx->os_over = 0;
+    if (ctx->ds_over == 0)
+    {
+        if (xpost_stack_count(ctx->lo, ctx->ds) > XPOST_DICT_STACK_LIMIT)
+        {
+            ctx->ds_over = 1;
+            return dictstackoverflow;
+        }
+    }
+    else if (xpost_stack_count(ctx->lo, ctx->ds) <= XPOST_DICT_STACK_LIMIT)
+        ctx->ds_over = 0;
+    return 0;
+}
+
 /* quit the interpreter */
 static
 int evalquit(Xpost_Context *ctx)
@@ -805,6 +855,7 @@ Xpost_Context *_switch_context(Xpost_Context *ctx)
 int mainloop(Xpost_Context *ctx)
 {
     int ret;
+    unsigned int evalcount = 0;
 
 ctxswitch:
     xpost_ctx = ctx = _switch_context(ctx);
@@ -826,6 +877,15 @@ ctxswitch:
             ctx->lo->garbage_collect_pending = 0;
             if (ctx->lo->garbage_collect_is_installed)
                 (void)ctx->lo->garbage_collect(ctx->lo, 1, 1);
+        }
+        if ((++evalcount & 1023) == 0)
+        {
+            int over = _stack_ceilings(ctx);
+            if (over)
+            {
+                _onerror(ctx, over);
+                continue;
+            }
         }
         ret = eval(ctx);
         if (ret)

--- a/src/lib/xpost_interpreter.c
+++ b/src/lib/xpost_interpreter.c
@@ -767,6 +767,15 @@ void _onerror(Xpost_Context *ctx,
             xpost_stack_push(ctx->lo, ctx->os,
                     xpost_stack_bottomup_fetch(ctx->lo, ctx->hold, i));
         }
+        /* the restored args carry the dispatcher's integer->real coercions;
+           put back the integers the program actually pushed (PLRM 3.11) */
+        for (i = 0; i < ctx->op_restore_n; i++)
+        {
+            int idx = ctx->op_restore_idx[i];
+            if (idx < n)
+                xpost_stack_topdown_replace(ctx->lo, ctx->os, idx,
+                        ctx->op_restore_val[i]);
+        }
     }
 
     /* printf("1\n"); */

--- a/src/lib/xpost_interpreter.c
+++ b/src/lib/xpost_interpreter.c
@@ -1340,6 +1340,7 @@ XPAPI int xpost_run(Xpost_Context *ctx, Xpost_Input_Type input_type, const void 
        and if it ever gets to the bottom, it quits.
        These procedures are all defined in data/init.ps
      */
+    ctx->es_run_base = xpost_stack_count(ctx->lo, ctx->es);
     xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons(ctx, "quit", NULL,0,0));
     /*
        if ps_file is NULL:
@@ -1383,7 +1384,20 @@ run:
                   xpost_stack_bottomup_fetch(ctx->lo, ctx->ds, 0),
                   xpost_name_cons(ctx, "ShowpageSemantics"));
     if (semantic.int_.val == XPOST_SHOWPAGE_RETURN)
+    {
+        if (ret != 1)
+        {
+            /* the run stops at its quit operator, leaving the frames
+               beneath it -- the run's own scheduling tail -- on the
+               exec stack. A persistent context serving many runs
+               accumulates them, and an error unwind can later walk
+               down into a stale frame and execute it out of context.
+               Discard everything this run left behind. */
+            while (xpost_stack_count(ctx->lo, ctx->es) > (int)ctx->es_run_base)
+                (void)xpost_stack_pop(ctx->lo, ctx->es);
+        }
         return ret == 1 ? yieldtocaller : 0;
+    }
 
     XPOST_LOG_INFO("destroying device");
     device = xpost_dict_get(ctx,

--- a/src/lib/xpost_interpreter.c
+++ b/src/lib/xpost_interpreter.c
@@ -623,9 +623,6 @@ int eval(Xpost_Context *ctx)
                                errant object since it is the "entry point" to the interpreter.
                              */
 
-    if (!validate_context(ctx))
-        return unregistered;
-
     if (_xpost_interpreter_is_tracing)
     {
         //XPOST_LOG_DUMP("eval(): Executing: ");
@@ -812,6 +809,12 @@ int mainloop(Xpost_Context *ctx)
 ctxswitch:
     xpost_ctx = ctx = _switch_context(ctx);
     itpdata->cid = ctx->id;
+
+    /* the context's memory pointers are fixed for the life of a run;
+       validate them once when a context becomes current rather than
+       before every evaluation step */
+    if (!validate_context(ctx))
+        return unregistered;
 
     while(!ctx->quit)
     {

--- a/src/lib/xpost_interpreter.c
+++ b/src/lib/xpost_interpreter.c
@@ -316,6 +316,16 @@ int evalfunc(Xpost_Context *ctx);
 #define XPOST_OPER_STACK_LIMIT 1000000
 #define XPOST_DICT_STACK_LIMIT 5000
 
+/* Ceiling on errors handled back-to-back without the run reaching `stop`.
+   A well-formed program recovers from every error through the error
+   machinery, which ends in `stop`; that resets the count (see
+   xpost_op_stop). Only a runaway cascade -- an error raised from inside
+   the error machinery itself, before it can reach `stop` -- accumulates
+   without bound. Left unchecked it spins until VM exhaustion; this makes
+   it abort the job cleanly instead. The bound is far above any legitimate
+   volume of caught-and-recovered errors, which never advance this count. */
+#define XPOST_ERROR_CASCADE_LIMIT 4096
+
 /* raise a stack's overflow error on crossing its ceiling; 0 if every
    stack is within bounds or already reported */
 static int _stack_ceilings(Xpost_Context *ctx)
@@ -724,6 +734,20 @@ void _onerror(Xpost_Context *ctx,
         fprintf(stderr, "LOOP in error handler\nabort\n");
         ++ctx->quit;
         /*exit(undefinedresult); */
+    }
+
+    /* A runaway error cascade re-enters here without ever reaching `stop`
+       (the error machinery raises before it can recover), so the nested
+       `in_onerror` guard above -- reset on every completed pass -- never
+       trips. Count consecutive handled errors instead and abort the job
+       when they run away, turning an otherwise unbounded spin into a
+       clean errored exit. xpost_op_stop clears the count on recovery. */
+    if (++ctx->onerr_run > XPOST_ERROR_CASCADE_LIMIT)
+    {
+        fprintf(stderr, "runaway error cascade (%s)\nabort\n",
+                errorname[err]);
+        ++ctx->quit;
+        return;
     }
 
     ++itpdata->in_onerror;
@@ -1403,8 +1427,13 @@ XPAPI int xpost_run(Xpost_Context *ctx, Xpost_Input_Type input_type, const void 
             ps_file_ptr = inputptr;
             break;
         case XPOST_INPUT_RESUME: /* resuming a returned session, skip startup */
+            /* the resumed run restarts the cascade count */
+            ctx->onerr_run = 0;
             goto run;
     }
+
+    /* a fresh run starts with a clean cascade count */
+    ctx->onerr_run = 0;
 
     /* prime the exec stack
        so it starts with a 'start*' procedure,

--- a/src/lib/xpost_interpreter.c
+++ b/src/lib/xpost_interpreter.c
@@ -467,6 +467,12 @@ int evalfile(Xpost_Context *ctx)
     int ret;
 
     f = xpost_stack_pop(ctx->lo, ctx->es);
+    /* a program may close the file it is executing from -- the
+       Type 1 font idiom mark currentfile closefile -- and a closed
+       file simply has nothing further to run */
+    if (!xpost_file_get_status(ctx->lo, f))
+        return 0;
+
     if (!xpost_stack_push(ctx->lo, ctx->os, f))
         return stackoverflow;
     assert(ctx->gl->base);

--- a/src/lib/xpost_interpreter.c
+++ b/src/lib/xpost_interpreter.c
@@ -1219,10 +1219,12 @@ XPAPI Xpost_Context *xpost_create(const char *device,
 
     if (quiet)
     {
+        /* a boolean, matching the convention of other interpreters:
+           programs test both `/QUIET where` and the value itself */
         xpost_dict_put(xpost_ctx,
                        sd /*xpost_stack_bottomup_fetch(ctx->lo, ctx->ds, 0)*/ ,
                        xpost_name_cons(xpost_ctx, "QUIET"),
-                       null);
+                       xpost_bool_cons(1));
     }
 
     xpost_stack_clear(xpost_ctx->lo, xpost_ctx->hold);

--- a/src/lib/xpost_log.c
+++ b/src/lib/xpost_log.c
@@ -209,13 +209,20 @@ _xpost_log_fprint_cb(FILE *stream,
 
     s = vsnprintf(NULL, 0, fmt, args);
     if (s == -1)
+    {
+        va_end(args_copy);
         return;
+    }
 
     str = (char *)malloc((s + 2) * sizeof(char));
     if (!str)
+    {
+        va_end(args_copy);
         return;
+    }
 
     s = vsnprintf(str, s + 1, fmt, args_copy);
+    va_end(args_copy);
     if (s == -1)
     {
         free(str);
@@ -384,14 +391,22 @@ xpost_log_print_dump(Xpost_Log_Level level,
     va_copy(args_copy, args);
 
     s = vsnprintf(NULL, 0, fmt, args);
+    va_end(args);
     if (s == -1)
+    {
+        va_end(args_copy);
         return;
+    }
 
     str = (char *)malloc((s + 2) * sizeof(char));
     if (!str)
+    {
+        va_end(args_copy);
         return;
+    }
 
     s = vsnprintf(str, s + 1, fmt, args_copy);
+    va_end(args_copy);
     if (s == -1)
     {
         free(str);
@@ -409,6 +424,4 @@ xpost_log_print_dump(Xpost_Log_Level level,
 
     if ((int)res != (s + 1))
         fprintf(stderr, "ERROR: %s(): want to write %d bytes, %d written\n", __func__, s + 1, res);
-
-    va_end(args);
 }

--- a/src/lib/xpost_main.c
+++ b/src/lib/xpost_main.c
@@ -94,11 +94,19 @@ xpost_init(void)
     l = strlen(_xpost_lib_dir);
     memcpy(tmp1, _xpost_lib_dir, l);
     memcpy(tmp1 + l, "/../share/xpost", sizeof("/../share/xpost"));
-    /* An uninstalled build has no <libdir>/../share/xpost, which is not fatal:
-       the interpreter's init.ps search falls back to XPOST_DATA_DIR and to
-       data/ relative paths (see setlocalconfig), so leave _xpost_data_dir
-       unset and carry on rather than failing to initialise. */
+    /* An uninstalled build has no <libdir>/../share/xpost: try the
+       source tree's data directory next, relative to the built library
+       (build/src/lib and src/lib/.libs both sit three levels below the
+       tree root), so the built interpreter runs from any directory.
+       A miss is not fatal -- the interpreter's init.ps search verifies
+       each candidate and falls back to XPOST_DATA_DIR and to data/
+       relative paths (see setlocalconfig). */
     _xpost_data_dir = xpost_realpath(tmp1);
+    if (!_xpost_data_dir)
+    {
+        memcpy(tmp1 + l, "/../../../data", sizeof("/../../../data"));
+        _xpost_data_dir = xpost_realpath(tmp1);
+    }
 
     if (!xpost_memory_init())
         return --_xpost_init_count;

--- a/src/lib/xpost_main.c
+++ b/src/lib/xpost_main.c
@@ -94,18 +94,11 @@ xpost_init(void)
     l = strlen(_xpost_lib_dir);
     memcpy(tmp1, _xpost_lib_dir, l);
     memcpy(tmp1 + l, "/../share/xpost", sizeof("/../share/xpost"));
+    /* An uninstalled build has no <libdir>/../share/xpost, which is not fatal:
+       the interpreter's init.ps search falls back to XPOST_DATA_DIR and to
+       data/ relative paths (see setlocalconfig), so leave _xpost_data_dir
+       unset and carry on rather than failing to initialise. */
     _xpost_data_dir = xpost_realpath(tmp1);
-    if (!_xpost_data_dir)
-    {
-        /* An uninstalled library has no ../share/xpost neighbour for
-           realpath() to resolve. Keep the unresolved path, as
-           GetFullPathName() does on Windows: the interpreter probes
-           several candidate directories for init.ps and passes over
-           those that do not exist. */
-        _xpost_data_dir = strdup(tmp1);
-        if (!_xpost_data_dir)
-            return --_xpost_init_count;
-    }
 
     if (!xpost_memory_init())
         return --_xpost_init_count;

--- a/src/lib/xpost_matrix.c
+++ b/src/lib/xpost_matrix.c
@@ -39,49 +39,6 @@
 #include "xpost_object.h"
 #include "xpost_matrix.h"
 
-#ifdef WANT_LARGE_OBJECT
-# define XPOST_ABS(x) fabs(x)
-# define XPOST_MOD(x,y) fmod(x, y)
-#else
-# define XPOST_ABS(x) fabsf(x)
-# define XPOST_MOD(x, y) fmodf(x, y)
-#endif
-
-/*
- * Fast sinus / cosinus computation :
- * http://devmaster.net/posts/9648/fast-and-accurate-sine-cosine
- */
-
-#define XPOST_EXTRA_PRECISION
-static real _sinus(real x)
-{
-    const real B = (real)(2.0 * M_2_PI);
-    const real C = (real)(-M_2_PI * M_2_PI);
-
-    real y = B * x + C * x * XPOST_ABS(x);
-
-#ifdef XPOST_EXTRA_PRECISION
-    /* const real Q = 0.775; */
-    const real P = 0.225f;
-
-    y = P * (y * XPOST_ABS(y) - y) + y;   /* Q * y + P * y * fabs(y) */
-#endif
-
-    return y;
-}
-
-static real _cosinus(real x)
-{
-    x += (real)M_PI_2;
-
-    if (x > M_PI)   /* Original x > pi/2 */
-    {
-        x -= (real)(2.0 * M_PI);   /* Wrap: cos(x) = cos(x - 2 pi) */
-    }
-
-    return _sinus(x);
-}
-
 void xpost_matrix_identity(Xpost_Matrix *m)
 {
     m->xx = 1.0;
@@ -120,9 +77,10 @@ void xpost_matrix_rotate(Xpost_Matrix *m, real rad)
     real c;
     real s;
 
-    rad = (real)XPOST_MOD(rad + M_PI, 2.0 * M_PI) - M_PI;
-    c = _cosinus(rad);
-    s = _sinus(rad);
+    /* the rotation lands in every subsequent coordinate: it must be
+       trigonometrically exact, not approximated */
+    c = (real)cos(rad);
+    s = (real)sin(rad);
 
     m->xx = c;
     m->xy = -s;

--- a/src/lib/xpost_memory.c
+++ b/src/lib/xpost_memory.c
@@ -779,6 +779,7 @@ xpost_memory_get(Xpost_Memory_File *mem,
     {
         XPOST_LOG_ERR("%d out of bounds memory %u * %u > %u", rangecheck,
                 offset, sz, mem->table.tab[ent].sz);
+        if (getenv("XPOST_TRAP_OOB")) abort(); /* P0 TEMP */
         return 0;
     }
 

--- a/src/lib/xpost_memory.c
+++ b/src/lib/xpost_memory.c
@@ -637,23 +637,14 @@ xpost_memory_table_alloc(Xpost_Memory_File *mem,
         }
         else if (ret == 2)
         {
+            /* collection is due, but running it here would sweep any
+               object the current operator holds only in C variables
+               (invisible to the root set). Record the request; the
+               interpreter collects at its safe point between operator
+               executions, where the stacks are the complete roots. */
             if (mem->garbage_collect_is_installed &&
                     !mem->interpreter_get_initializing())
-            {
-                int sz_reclaimed;
-
-                sz_reclaimed = mem->garbage_collect(mem, 1, 1);
-                if (sz_reclaimed == -1)
-                    return 0;
-                if (sz_reclaimed > (int)sz)
-                {
-                    ret = mem->free_list_alloc(mem, sz, tag, entity);
-                    if (ret == 1)
-                    {
-                        return 1;
-                    }
-                }
-            }
+                mem->garbage_collect_pending = 1;
         }
     }
     ret = _xpost_memory_table_alloc_new(mem, sz, tag, entity);

--- a/src/lib/xpost_memory.c
+++ b/src/lib/xpost_memory.c
@@ -440,7 +440,10 @@ xpost_memory_file_grow(Xpost_Memory_File *mem,
 #endif
         /* common error case closes the three possible hanging error cases */
         XPOST_LOG_ERR("%d unable to grow memory", VMerror);
-        ret = 0;
+        /* leave the existing mapping in place: publishing the failed base
+           (MAP_FAILED or NULL) would turn a recoverable VMerror into a wild
+           dereference on the very next memory access */
+        return 0;
     }
     mem->base = (unsigned char *)tmp;
     mem->max = sz;
@@ -810,7 +813,9 @@ xpost_memory_get(Xpost_Memory_File *mem,
 {
     CHECK_VALID_ENT(ent,mem,0)
 
-    if (offset * sz + sz > mem->table.tab[ent].sz)
+    /* offset is an index added to the composite's base; compute the bound in
+       64 bits so offset*sz cannot wrap a 32-bit unsigned past the check */
+    if ((unsigned long long)offset * sz + sz > mem->table.tab[ent].sz)
     {
         XPOST_LOG_ERR("%d out of bounds memory %u * %u > %u", rangecheck,
                 offset, sz, mem->table.tab[ent].sz);
@@ -832,7 +837,7 @@ xpost_memory_put(Xpost_Memory_File *mem,
 {
     CHECK_VALID_ENT(ent,mem,0)
 
-    if (offset * sz + sz > mem->table.tab[ent].sz)
+    if ((unsigned long long)offset * sz + sz > mem->table.tab[ent].sz)
     {
         XPOST_LOG_ERR("%d out of bounds memory %u * %u > %u", rangecheck,
                 offset, sz, mem->table.tab[ent].sz);

--- a/src/lib/xpost_memory.c
+++ b/src/lib/xpost_memory.c
@@ -649,6 +649,8 @@ xpost_memory_table_alloc(Xpost_Memory_File *mem,
         }
     }
     ret = _xpost_memory_table_alloc_new(mem, sz, tag, entity);
+    if (!ret)
+        return 0; /* *entity is not valid on failure */
     //XPOST_LOG_INFO("allocated %u(%u) bytes with tag %u as ent %u at %u in %s", sz, mem->table.tab[*entity].sz, tag, *entity, mem->table.tab[*entity].adr, mem->fname);
     mem->table.tab[*entity].used = sz;
     return ret;

--- a/src/lib/xpost_memory.c
+++ b/src/lib/xpost_memory.c
@@ -405,6 +405,19 @@ xpost_memory_file_grow(Xpost_Memory_File *mem,
 #else
     /* initialize mem (valgrind) */
     memset(mem->base + mem->used, 0, mem->max - mem->used);
+    if (getenv("XPOST_GROW_MOVES"))
+    {
+        /* debug: force every grow to relocate, so a stale pointer into
+           the old buffer is a use-after-free that ASan reports */
+        tmp = malloc(sz);
+        if (tmp != NULL)
+        {
+            memcpy(tmp, mem->base, mem->used);
+            memset((unsigned char *)tmp + mem->used, 0, sz - mem->used);
+            free(mem->base);
+        }
+    }
+    else
     tmp = realloc(mem->base, sz);
     if (tmp == NULL)
     { /* hanging error case */
@@ -781,7 +794,7 @@ xpost_memory_get(Xpost_Memory_File *mem,
 {
     CHECK_VALID_ENT(ent,mem,0)
 
-    if (offset * sz > mem->table.tab[ent].sz)
+    if (offset * sz + sz > mem->table.tab[ent].sz)
     {
         XPOST_LOG_ERR("%d out of bounds memory %u * %u > %u", rangecheck,
                 offset, sz, mem->table.tab[ent].sz);
@@ -803,7 +816,7 @@ xpost_memory_put(Xpost_Memory_File *mem,
 {
     CHECK_VALID_ENT(ent,mem,0)
 
-    if (offset * sz > mem->table.tab[ent].sz)
+    if (offset * sz + sz > mem->table.tab[ent].sz)
     {
         XPOST_LOG_ERR("%d out of bounds memory %u * %u > %u", rangecheck,
                 offset, sz, mem->table.tab[ent].sz);

--- a/src/lib/xpost_memory.c
+++ b/src/lib/xpost_memory.c
@@ -630,6 +630,18 @@ xpost_memory_table_alloc(Xpost_Memory_File *mem,
 
     if (mem->free_list_alloc_is_installed)
     {
+        /* entity numbers are a fixed budget independent of the byte
+           threshold: collect well before the table saturates, or
+           allocation fails outright once it does */
+        if (mem->garbage_collect_is_installed &&
+            !mem->interpreter_get_initializing() &&
+            mem->table.nextent > XPOST_OBJECT_COMP_MAX_ENT / 2 &&
+            mem->table.nextent >= mem->gc_trigger_nextent)
+        {
+            mem->garbage_collect_pending = 1;
+            mem->gc_trigger_nextent = mem->table.nextent + 65536;
+        }
+
         ret = mem->free_list_alloc(mem, sz, tag, entity);
         if (ret == 1)
         {

--- a/src/lib/xpost_memory.c
+++ b/src/lib/xpost_memory.c
@@ -474,23 +474,29 @@ xpost_memory_file_alloc(Xpost_Memory_File *mem,
         return 0;
     }
 
-    adr = mem->used;
+    /* 8-align every allocation so structs stored in the file -- dict
+       headers, name-tree nodes, operator signatures, objects -- are read
+       and written at their natural alignment (the file base is already
+       aligned). The bytes skipped before an aligned address are padding
+       within the file; entities are located by their recorded address, not
+       by walking the file, so the gap is harmless. */
+    adr = (mem->used + 7u) & ~7u;
 
     if (sz)
     {
-        if ((size_t)sz + mem->used >= mem->max)
+        if ((size_t)adr + sz >= mem->max)
         {
-            if (!xpost_memory_file_grow(mem, sz))
+            if (!xpost_memory_file_grow(mem, (adr - mem->used) + sz))
             {
                 XPOST_LOG_ERR("%d unable to allocate memory", VMerror);
                 return 0;
             }
         }
 
-        mem->used += sz;
         memset(mem->base + adr, 0, sz);
     }
 
+    mem->used = adr + sz;
     *retaddr = adr;
     //XPOST_LOG_INFO("allocated %u bytes at %u in %s", sz, adr, mem->fname);
     return 1;

--- a/src/lib/xpost_memory.c
+++ b/src/lib/xpost_memory.c
@@ -580,12 +580,15 @@ _xpost_memory_table_alloc_new(Xpost_Memory_File *mem,
     }
 
     ent = mem->table.nextent;
-    ++mem->table.nextent;
     if (ent > XPOST_OBJECT_COMP_MAX_ENT)
     {
-        XPOST_LOG_ERR("Warning: ent number %u exceeds object extended-ent-field max %u",
-                ent, XPOST_OBJECT_COMP_MAX_ENT);
+        /* an ent number beyond the object field width would be silently
+           truncated when stored in an object, aliasing another entity */
+        XPOST_LOG_ERR("%d entity numbers exhausted (max %u)",
+                VMerror, XPOST_OBJECT_COMP_MAX_ENT);
+        return 0;
     }
+    ++mem->table.nextent;
 
     if (!xpost_memory_file_alloc(mem, sz, &adr))
     {

--- a/src/lib/xpost_memory.c
+++ b/src/lib/xpost_memory.c
@@ -633,6 +633,7 @@ xpost_memory_table_alloc(Xpost_Memory_File *mem,
         ret = mem->free_list_alloc(mem, sz, tag, entity);
         if (ret == 1)
         {
+            mem->table.tab[*entity].used = sz;
             return 1;
         }
         else if (ret == 2)

--- a/src/lib/xpost_memory.c
+++ b/src/lib/xpost_memory.c
@@ -313,7 +313,23 @@ xpost_memory_file_grow(Xpost_Memory_File *mem,
         sz = xpost_memory_page_size;
     else
         sz = (sz / xpost_memory_page_size + 1) * xpost_memory_page_size;
-    sz += mem->max * 1.5;
+    {
+        /* objects address the file through unsigned int offsets, which
+           caps a memory file at 4G: clamp the geometric growth to that
+           limit and fail once a request itself no longer fits, so the
+           caller raises VMerror instead of wrapping the size */
+        size_t req = sz;
+        sz += (size_t)(mem->max * 1.5);
+        if (sz > 0xffffffffu)
+        {
+            if ((size_t)mem->used + req > 0xffffffffu)
+            {
+                XPOST_LOG_ERR("%d memory file full: cannot grow beyond addressable size", VMerror);
+                return 0;
+            }
+            sz = 0xffffffffu;
+        }
+    }
 
     XPOST_LOG_INFO("grow memory file%s%s (old: %d  new: %d)",
                    mem->fname[0] ? " for " : "", mem->fname[0] ? mem->fname : "",
@@ -459,7 +475,7 @@ xpost_memory_file_alloc(Xpost_Memory_File *mem,
 
     if (sz)
     {
-        if (sz + mem->used >= mem->max)
+        if ((size_t)sz + mem->used >= mem->max)
         {
             if (!xpost_memory_file_grow(mem, sz))
             {

--- a/src/lib/xpost_memory.h
+++ b/src/lib/xpost_memory.h
@@ -164,6 +164,11 @@ typedef struct Xpost_Memory_File
                            unsigned int *entity);
 
     int garbage_collect_is_installed;
+    int garbage_collect_pending; /**< a collection is due; performed at the
+                                      interpreter's safe point rather than
+                                      inside the triggering allocation, so
+                                      operator-internal intermediates held
+                                      only in C variables cannot be swept */
     int (*garbage_collect)(struct Xpost_Memory_File *mem,
                            int dosweep,
                            int markall);

--- a/src/lib/xpost_memory.h
+++ b/src/lib/xpost_memory.h
@@ -164,6 +164,12 @@ typedef struct Xpost_Memory_File
                            unsigned int *entity);
 
     int garbage_collect_is_installed;
+    unsigned int gc_trigger_nextent; /**< entity-pressure trigger: re-arms
+                                           only after the table grows past
+                                           this point (the count is
+                                           monotonic, so a level trigger
+                                           would re-request on every
+                                           allocation) */
     int garbage_collect_pending; /**< a collection is due; performed at the
                                       interpreter's safe point rather than
                                       inside the triggering allocation, so

--- a/src/lib/xpost_memory.h
+++ b/src/lib/xpost_memory.h
@@ -155,6 +155,13 @@ typedef struct Xpost_Memory_File
     unsigned int start; /**< first 'live' entry in the memory_table. */
         /* the domain of the collector is entries >= start */
 
+    unsigned int free_substack; /**< one recycled save-record substack, or 0.
+                                     Save-record stacks are raw file allocations,
+                                     not table entities, so the collector cannot
+                                     reclaim them; restore parks an emptied one
+                                     here for the next save to reuse instead of
+                                     leaking it (see xpost_save.c). */
+
     int period;
     int threshold;
     int free_list_alloc_is_installed;

--- a/src/lib/xpost_name.c
+++ b/src/lib/xpost_name.c
@@ -306,6 +306,45 @@ Xpost_Object xpost_name_cons(Xpost_Context *ctx,
     return o;
 }
 
+/* construct a name object in global VM regardless of the current
+   allocation mode, ignoring any local interning of the same string.
+   The operator table records names by their global index; resolving
+   an operator name through the local tree can alias a different
+   global name with the same numeric index. */
+Xpost_Object xpost_name_cons_global(Xpost_Context *ctx,
+                                    const char *s)
+{
+    unsigned int u;
+    unsigned int t;
+    Xpost_Object o;
+    unsigned int tstk;
+    int ret;
+
+    xpost_memory_table_get_addr(ctx->gl,
+            XPOST_MEMORY_TABLE_SPECIAL_NAME_TREE, &tstk);
+    u = tstsearch(ctx->gl, tstk, s);
+    if (!u) {
+        unsigned int vmmode = ctx->vmmode;
+        Xpost_Memory_Table *tab = &ctx->gl->table;
+
+        ctx->vmmode = GLOBAL;
+        ret = tstinsert(ctx->gl, tab->tab[XPOST_MEMORY_TABLE_SPECIAL_NAME_TREE].adr, s, &t);
+        if (ret)
+        {
+            ctx->vmmode = vmmode;
+            return invalid;
+        }
+        tab = &ctx->gl->table; //recalc pointer
+        tab->tab[XPOST_MEMORY_TABLE_SPECIAL_NAME_TREE].adr = t;
+        u = addname(ctx, s);
+        ctx->vmmode = vmmode;
+    }
+    o.mark_.tag = nametype | XPOST_OBJECT_TAG_DATA_FLAG_BANK;
+    o.mark_.pad0 = 0;
+    o.mark_.padw = u;
+    return o;
+}
+
 /* yield the string object from the name string stack
     */
 Xpost_Object xpost_name_get_string(Xpost_Context *ctx,

--- a/src/lib/xpost_name.h
+++ b/src/lib/xpost_name.h
@@ -53,6 +53,13 @@ typedef struct tst
 void xpost_name_dump_names(Xpost_Context *ctx);
 int xpost_name_init(Xpost_Context *ctx);
 Xpost_Object xpost_name_cons(Xpost_Context *ctx, const char *s);
+
+/**
+ * @brief Construct a name object in global VM regardless of the
+ * current allocation mode. Operator names must live in the global
+ * name space: the operator table records them by global index.
+ */
+Xpost_Object xpost_name_cons_global(Xpost_Context *ctx, const char *s);
 Xpost_Object xpost_name_get_string(Xpost_Context *ctx, Xpost_Object n);
 
 /**

--- a/src/lib/xpost_object.c
+++ b/src/lib/xpost_object.c
@@ -182,7 +182,12 @@ Xpost_Object xpost_object_get_interval(Xpost_Object a,
                       integer off,
                       integer sz)
 {
-    if (sz - off > a.comp_.sz)
+    /* the interval [off, off+sz) must lie within the composite. Compare
+       without overflow: off and sz are non-negative and comp_.sz is small,
+       so require off <= comp_.sz and sz <= comp_.sz - off. */
+    if (off < 0 || sz < 0
+        || (unsigned)off > a.comp_.sz
+        || (unsigned)sz > a.comp_.sz - (unsigned)off)
         return invalid; /* should be interpreted as a rangecheck error */
     a.comp_.off += off;
     a.comp_.sz = sz;

--- a/src/lib/xpost_op_array.c
+++ b/src/lib/xpost_op_array.c
@@ -81,6 +81,11 @@ int xpost_op_int_array (Xpost_Context *ctx,
 {
     Xpost_Object t;
 
+    if (I.int_.val < 0)
+        return rangecheck;
+    if (I.int_.val > 65535) /* sz field is 16 bits; PLRM minimum limit */
+        return limitcheck;
+
     t = xpost_array_cons(ctx, I.int_.val);
     if (xpost_object_get_type(t) == nulltype)
         return VMerror;

--- a/src/lib/xpost_op_array.c
+++ b/src/lib/xpost_op_array.c
@@ -112,6 +112,10 @@ int xpost_op_array_to_mark (Xpost_Context *ctx)
     if (xpost_object_get_type(t) == invalidtype)
         return stackunderflow;
     i = t.int_.val;
+    if (i > 65535) /* sz field is 16 bits, as the array operator enforces:
+                      raise limitcheck rather than let array_cons truncate the
+                      length and then fault putting the discarded elements */
+        return limitcheck;
     a = xpost_array_cons(ctx, i);
     if (xpost_object_get_type(a) == nulltype)
         return VMerror;

--- a/src/lib/xpost_op_context.c
+++ b/src/lib/xpost_op_context.c
@@ -80,7 +80,6 @@ int xpost_op_fork (Xpost_Context *ctx, Xpost_Object proc)
                               ctx->xpost_interpreter_alloc_global_memory,
                               ctx->garbage_collect_function);
     newctx = ctx->gl->interpreter_cid_get_context(cid);
-    printf("op_fork ctx->id %u, cid %u, newctx->id %u\n", ctx->id, cid, newctx->id);
 
     (void)xpost_op_counttomark(ctx);
     n = xpost_stack_pop(ctx->lo, ctx->os).int_.val;
@@ -107,7 +106,6 @@ static
 int _i_am_zombie_ (Xpost_Context *ctx)
 {
     ctx->state = C_ZOMB;
-    printf("I AM ZOMBIE\n");
     return contextswitch;
 }
 
@@ -115,7 +113,6 @@ static
 int _i_am_free_ (Xpost_Context *ctx)
 {
     ctx->state = C_FREE;
-    printf("I AM FREE\n");
     return contextswitch;
 }
 
@@ -130,7 +127,6 @@ int xpost_op_join (Xpost_Context *ctx, Xpost_Object context)
     Xpost_Context *child = ctx->gl->interpreter_cid_get_context(context.mark_.padw);
     if (child->state == C_ZOMB) {
         int i,n;
-        printf("found zombie child\n");
         xpost_stack_push(ctx->lo, ctx->os, mark);
         // Copy operand stack
         n = xpost_stack_count(child->lo, child->os);
@@ -143,7 +139,6 @@ int xpost_op_join (Xpost_Context *ctx, Xpost_Object context)
     }
 
     /* continue */
-    printf("waiting for child %u ==%u\n", context.mark_.padw, child->state);
     xpost_stack_push(ctx->lo, ctx->os, context);
     xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons(ctx, "join", NULL,0,0));
     ctx->state = C_WAIT;

--- a/src/lib/xpost_op_control.c
+++ b/src/lib/xpost_op_control.c
@@ -300,6 +300,7 @@ int xpost_op_stop(Xpost_Context *ctx)
        errordict, whose handlers themselves finish with `stop`,
        recursing without bound. */
     XPOST_LOG_ERR("no stopped context in 'stop'");
+    if (getenv("XPOST_TRAP_NOSTOP")) abort(); /* P0 TEMP */
     ctx->quit = 1;
     return 0;
 }

--- a/src/lib/xpost_op_control.c
+++ b/src/lib/xpost_op_control.c
@@ -295,8 +295,13 @@ int xpost_op_stop(Xpost_Context *ctx)
             return 0;
         }
     }
+    /* PLRM: stop with no enclosing stopped context prints a message
+       and executes quit.  Returning an error here would re-enter
+       errordict, whose handlers themselves finish with `stop`,
+       recursing without bound. */
     XPOST_LOG_ERR("no stopped context in 'stop'");
-    return unregistered;
+    ctx->quit = 1;
+    return 0;
 }
 
 /* any  stopped  bool

--- a/src/lib/xpost_op_control.c
+++ b/src/lib/xpost_op_control.c
@@ -283,6 +283,10 @@ int xpost_op_stop(Xpost_Context *ctx)
 {
     Xpost_Object f = xpost_bool_cons(0);
     Xpost_Object x;
+    /* Reaching `stop` means the error machinery ran to completion and the
+       run is recovering (or quitting cleanly): the error cascade, if any,
+       has broken. Clear the consecutive-error count that _onerror keeps. */
+    ctx->onerr_run = 0;
     /* Unwind the exec stack to the nearest enclosing stopped context --
        the false that `stopped` pushed. Pop straight to it: counting the
        whole stack first to bound the loop is O(depth) yet the marker is

--- a/src/lib/xpost_op_control.c
+++ b/src/lib/xpost_op_control.c
@@ -185,7 +185,10 @@ int xpost_op_int_proc_repeat (Xpost_Context *ctx,
                               Xpost_Object n,
                               Xpost_Object P)
 {
-    if (n.int_.val <= 0) return 0;
+    /* PLRM: the count must be a nonnegative integer -- a negative one is
+       rangecheck, not a silent no-op; zero legitimately does nothing */
+    if (n.int_.val < 0) return rangecheck;
+    if (n.int_.val == 0) return 0;
 
     if (!xpost_stack_push(ctx->lo, ctx->es,
                           xpost_operator_cons_opcode(ctx->opcode_shortcuts.repeat)))

--- a/src/lib/xpost_op_control.c
+++ b/src/lib/xpost_op_control.c
@@ -282,13 +282,17 @@ static
 int xpost_op_stop(Xpost_Context *ctx)
 {
     Xpost_Object f = xpost_bool_cons(0);
-    int c = xpost_stack_count(ctx->lo, ctx->es);
     Xpost_Object x;
-    while (c--)
+    /* Unwind the exec stack to the nearest enclosing stopped context --
+       the false that `stopped` pushed. Pop straight to it: counting the
+       whole stack first to bound the loop is O(depth) yet the marker is
+       usually a few frames down, and an emptied stack (the pop yields
+       invalidtype) is itself the no-context case handled below. */
+    for (;;)
     {
         x = xpost_stack_pop(ctx->lo, ctx->es);
         if (xpost_object_get_type(x) == invalidtype)
-            return execstackunderflow;
+            break;
         if(xpost_dict_compare_objects(ctx, f, x) == 0) {
             if (!xpost_stack_push(ctx->lo, ctx->os, xpost_bool_cons(1)))
                 return stackoverflow;

--- a/src/lib/xpost_op_control.c
+++ b/src/lib/xpost_op_control.c
@@ -103,6 +103,16 @@ int xpost_op_bool_proc_proc_ifelse (Xpost_Context *ctx,
     return 0;
 }
 
+/* the control value's type follows initial and increment, not the limit
+   (PLRM): an integer counter with a real limit still steps through integers,
+   so read the limit as a real for the termination test without promoting the
+   counter */
+static double _for_limit(Xpost_Object lim)
+{
+    return xpost_object_get_type(lim) == realtype
+        ? (double)lim.real_.val : (double)lim.int_.val;
+}
+
 /* initial increment limit proc  for  -
    execute proc with values from initial by steps
    of increment to limit */
@@ -115,7 +125,7 @@ int xpost_op_int_int_int_proc_for (Xpost_Context *ctx,
 {
     integer i = init.int_.val;
     integer j = incr.int_.val;
-    integer n = lim.int_.val;
+    double n = _for_limit(lim);
     int up = j > 0;
     if (up? i > n : i < n) return 0;
     assert(ctx->gl->base);
@@ -394,7 +404,7 @@ int xpost_oper_init_control_ops (Xpost_Context *ctx,
     op = xpost_operator_cons(ctx, "ifelse", (Xpost_Op_Func)xpost_op_bool_proc_proc_ifelse, 0, 3, booleantype, proctype, proctype);
     INSTALL;
     op = xpost_operator_cons(ctx, "for", (Xpost_Op_Func)xpost_op_int_int_int_proc_for, 0, 4, \
-                             integertype, integertype, integertype, proctype);
+                             integertype, integertype, numbertype, proctype);
     INSTALL;
     op = xpost_operator_cons(ctx, "for", (Xpost_Op_Func)xpost_op_real_real_real_proc_for, 0, 4, \
                              floattype, floattype, floattype, proctype);

--- a/src/lib/xpost_op_dict.c
+++ b/src/lib/xpost_op_dict.c
@@ -136,7 +136,7 @@ int xpost_op_dict_maxlength(Xpost_Context *ctx,
                             Xpost_Object D)
 {
     xpost_stack_push(ctx->lo, ctx->os,
-                     xpost_int_cons(xpost_dict_max_length_memory(xpost_context_select_memory(ctx, D) /*D.tag&FBANK?ctx->gl:ctx->lo*/,
+                     xpost_int_cons(xpost_dict_requested_length_memory(xpost_context_select_memory(ctx, D),
                                                                  D)));
     return 0;
 }

--- a/src/lib/xpost_op_dict.c
+++ b/src/lib/xpost_op_dict.c
@@ -64,6 +64,12 @@ int xpost_op_int_dict(Xpost_Context *ctx,
                       Xpost_Object I)
 {
     Xpost_Object dic;
+
+    if (I.int_.val < 0)
+        return rangecheck;
+    if (I.int_.val > 65535) /* sz field is 16 bits; PLRM minimum limit */
+        return limitcheck;
+
     dic = xpost_dict_cons (ctx, I.int_.val);
     if (xpost_object_get_type(dic) == nulltype)
         return VMerror;

--- a/src/lib/xpost_op_dict.c
+++ b/src/lib/xpost_op_dict.c
@@ -376,7 +376,7 @@ int xpost_op_dict_proc_forall (Xpost_Context *ctx,
     Xpost_Memory_File *mem = xpost_context_select_memory(ctx, D);
     assert(mem->base);
     D.comp_.sz = xpost_dict_max_length_memory (mem, D); // cache size locally
-    if (D.comp_.off <= D.comp_.sz) // FIXME: not finished?
+    if (D.comp_.off < DICTABN(D.comp_.sz)) // resume unless cursor is past the table
     {
         unsigned ad;
         dicrec *tp; /* dict Table Pointer */

--- a/src/lib/xpost_op_dict.c
+++ b/src/lib/xpost_op_dict.c
@@ -98,6 +98,10 @@ int xpost_op_dict_to_mark(Xpost_Context *ctx)
     i = t.int_.val;
     if ((i % 2) == 1)
         return rangecheck;
+    if (i > 65535) /* sz field is 16 bits, as the dict operator enforces:
+                      raise limitcheck rather than let dict_cons truncate the
+                      capacity and then fault putting the discarded pairs */
+        return limitcheck;
     d = xpost_object_cvlit(xpost_dict_cons (ctx, i));
     if (xpost_object_get_type(d) == nulltype)
         return VMerror;

--- a/src/lib/xpost_op_file.c
+++ b/src/lib/xpost_op_file.c
@@ -400,6 +400,33 @@ int xpost_op_file_status (Xpost_Context *ctx,
     return 0;
 }
 
+/* string  status  pages bytes referred created true | false
+   report on a named file: its block count, size, and access and modification
+   times if it exists and the sandbox permits it, otherwise false */
+static
+int xpost_op_string_status (Xpost_Context *ctx,
+                            Xpost_Object S)
+{
+    char *sbuf;
+    long pages, bytes, referred, created;
+    int exists;
+
+    sbuf = xpost_string_allocate_cstring(ctx, S);
+    if (!sbuf)
+        return VMerror;
+    exists = xpost_diskfile_stat(sbuf, &pages, &bytes, &referred, &created);
+    free(sbuf);
+    if (exists)
+    {
+        xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons(pages));
+        xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons(bytes));
+        xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons(referred));
+        xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons(created));
+    }
+    xpost_stack_push(ctx->lo, ctx->os, xpost_bool_cons(exists));
+    return 0;
+}
+
 /* -  currentfile  file
    return topmost file from the exec stack. The result carries the
    literal attribute (PLRM): programs stash it under a name and a
@@ -664,6 +691,8 @@ int xpost_oper_init_file_ops (Xpost_Context *ctx,
     INSTALL;
 #endif
     op = xpost_operator_cons(ctx, "status", (Xpost_Op_Func)xpost_op_file_status, 1, 1, filetype);
+    INSTALL;
+    op = xpost_operator_cons(ctx, "status", (Xpost_Op_Func)xpost_op_string_status, 5, 1, stringtype);
     INSTALL;
     /* string status */
     /* run: see init.ps */

--- a/src/lib/xpost_op_file.c
+++ b/src/lib/xpost_op_file.c
@@ -123,7 +123,11 @@ int xpost_op_file_read(Xpost_Context *ctx,
         return invalidaccess;
     b = xpost_file_read_byte(ctx->lo, f);
     if (xpost_object_get_type(b) == invalidtype)
-        return ioerror;
+    {
+        /* a closed file reads as end-of-data rather than erroring */
+        xpost_stack_push(ctx->lo, ctx->os, xpost_bool_cons(0));
+        return 0;
+    }
     if (b.int_.val != EOF)
     {
         xpost_stack_push(ctx->lo, ctx->os, b);
@@ -179,7 +183,13 @@ int xpost_op_file_readhexstring (Xpost_Context *ctx,
     Xpost_File *f;
     char *s;
     if (!xpost_file_get_status(ctx->lo, F))
-        return ioerror;
+    {
+        /* a closed file reads as end-of-data rather than erroring */
+        S.comp_.sz = 0;
+        xpost_stack_push(ctx->lo, ctx->os, S);
+        xpost_stack_push(ctx->lo, ctx->os, xpost_bool_cons(0));
+        return 0;
+    }
     if (!xpost_object_is_readable(ctx,F))
         return invalidaccess;
     f = xpost_file_get_file_pointer(ctx->lo, F);
@@ -241,7 +251,13 @@ int xpost_op_file_readstring (Xpost_Context *ctx,
     Xpost_File *f;
     char *s;
     if (!xpost_file_get_status(ctx->lo, F))
-        return ioerror;
+    {
+        /* a closed file reads as end-of-data rather than erroring */
+        S.comp_.sz = 0;
+        xpost_stack_push(ctx->lo, ctx->os, S);
+        xpost_stack_push(ctx->lo, ctx->os, xpost_bool_cons(0));
+        return 0;
+    }
     if (!xpost_object_is_readable(ctx,F))
         return invalidaccess;
     f = xpost_file_get_file_pointer(ctx->lo, F);
@@ -293,7 +309,13 @@ int xpost_op_file_readline (Xpost_Context *ctx,
     char *s;
     int n, c = ' ';
     if (!xpost_file_get_status(ctx->lo, F))
-        return ioerror;
+    {
+        /* a closed file reads as end-of-data rather than erroring */
+        S.comp_.sz = 0;
+        xpost_stack_push(ctx->lo, ctx->os, S);
+        xpost_stack_push(ctx->lo, ctx->os, xpost_bool_cons(0));
+        return 0;
+    }
     if (!xpost_object_is_readable(ctx,F))
         return invalidaccess;
     f = xpost_file_get_file_pointer(ctx->lo, F);

--- a/src/lib/xpost_op_file.c
+++ b/src/lib/xpost_op_file.c
@@ -303,9 +303,18 @@ int xpost_op_file_readline (Xpost_Context *ctx,
         c = xpost_file_getc(f);
         if (c == EOF || c == '\n')
             break;
+        if (c == '\r')
+        {
+            /* CR, LF and CRLF each end the line (PLRM 3.8): consume
+               the whole marker, return the line without it */
+            int c2 = xpost_file_getc(f);
+            if (c2 != '\n' && c2 != EOF)
+                xpost_file_ungetc(f, c2);
+            break;
+        }
         s[n] = c;
     }
-    if (n == S.comp_.sz && c != '\n')
+    if (n == S.comp_.sz && c != '\n' && c != '\r')
         return rangecheck;
     S.comp_.sz = n;
     xpost_stack_push(ctx->lo, ctx->os, S);

--- a/src/lib/xpost_op_file.c
+++ b/src/lib/xpost_op_file.c
@@ -401,7 +401,9 @@ int xpost_op_file_status (Xpost_Context *ctx,
 }
 
 /* -  currentfile  file
-   return topmost file from the exec stack */
+   return topmost file from the exec stack. The result carries the
+   literal attribute (PLRM): programs stash it under a name and a
+   later lookup must push the stashed file, not resume executing it. */
 static
 int xpost_op_currentfile (Xpost_Context *ctx)
 {
@@ -413,14 +415,14 @@ int xpost_op_currentfile (Xpost_Context *ctx)
         o = xpost_stack_topdown_fetch(ctx->lo, ctx->es, i);
         if (xpost_object_get_type(o) == filetype)
         {
-            xpost_stack_push(ctx->lo, ctx->os, o);
+            xpost_stack_push(ctx->lo, ctx->os, xpost_object_cvlit(o));
             return 0;
         }
     }
     o = xpost_file_cons(ctx->lo, NULL);
     if (xpost_object_get_type(o) == invalidtype)
         return VMerror;
-    xpost_stack_push(ctx->lo, ctx->os, o);
+    xpost_stack_push(ctx->lo, ctx->os, xpost_object_cvlit(o));
     return 0;
 }
 

--- a/src/lib/xpost_op_file.c
+++ b/src/lib/xpost_op_file.c
@@ -407,17 +407,13 @@ int xpost_op_file_status (Xpost_Context *ctx,
 static
 int xpost_op_currentfile (Xpost_Context *ctx)
 {
-    int z = xpost_stack_count(ctx->lo, ctx->es);
-    int i;
     Xpost_Object o;
-    for (i = 0; i<z; i++)
+    /* topmost file on the exec stack, found in a single top-down pass (the
+       former topdown_fetch-per-index loop was O(depth^2)) */
+    if (xpost_stack_topdown_find_type(ctx->lo, ctx->es, filetype, &o) >= 0)
     {
-        o = xpost_stack_topdown_fetch(ctx->lo, ctx->es, i);
-        if (xpost_object_get_type(o) == filetype)
-        {
-            xpost_stack_push(ctx->lo, ctx->os, xpost_object_cvlit(o));
-            return 0;
-        }
+        xpost_stack_push(ctx->lo, ctx->os, xpost_object_cvlit(o));
+        return 0;
     }
     o = xpost_file_cons(ctx->lo, NULL);
     if (xpost_object_get_type(o) == invalidtype)

--- a/src/lib/xpost_op_file.c
+++ b/src/lib/xpost_op_file.c
@@ -548,7 +548,10 @@ int xpost_op_contfilenameforall (Xpost_Context *ctx,
     }
     else
     {
-        xpost_glob_free(globbuf); /* reference has already been popped */
+        /* iteration is complete and the reference has already been popped:
+           release the matched paths and the container filenameforall allocated */
+        xpost_glob_free(globbuf);
+        free(globbuf);
     }
     return 0;
 }

--- a/src/lib/xpost_op_font.c
+++ b/src/lib/xpost_op_font.c
@@ -36,6 +36,7 @@
 #include <stddef.h>
 
 #include <assert.h>
+#include <math.h> /* sqrt */
 #include <stdio.h>
 #include <string.h>
 
@@ -251,6 +252,46 @@ int _setfont(Xpost_Context *ctx,
 }
 
 #ifdef HAVE_FREETYPE2
+/* Give the face the current orientation before using it. The pixel
+   size set by scalefont carries the CTM's magnitude (the scalefont
+   wrapper in font.ps measures the size through dtransform), so glyphs
+   come out the right size but always upright. Rotation, shear and
+   anisotropy live in the CTM's linear part: normalize the magnitude
+   out and conjugate by the y flip that relates FreeType's y-up glyph
+   space to the device's y-down raster, and install the result as the
+   face's transform. The face is shared through the font cache and the
+   transform is sticky, so each text operator refreshes it from the
+   graphics state it runs under. */
+static
+void _face_transform_from_ctm(Xpost_Context *ctx,
+                              Xpost_Object gs,
+                              void *face)
+{
+    Xpost_Object psmat;
+    real m[4];
+    real q;
+    float mat[6] = { 0 };
+    int i;
+
+    psmat = xpost_dict_get(ctx, gs, xpost_name_cons(ctx, "currmatrix"));
+    if (xpost_object_get_type(psmat) != arraytype || psmat.comp_.sz != 6)
+        return;
+    for (i = 0; i < 4; i++)
+    {
+        Xpost_Object el = xpost_array_get(ctx, psmat, i);
+        m[i] = xpost_object_get_type(el) == realtype ? el.real_.val
+             : (real)el.int_.val;
+    }
+    q = (real)sqrt(m[0] * m[0] + m[1] * m[1]);
+    if (q == 0)
+        return;
+    mat[0] = (float)( m[0] / q);   /* xx */
+    mat[1] = (float)( m[2] / q);   /* xy */
+    mat[2] = (float)(-m[1] / q);   /* yx */
+    mat[3] = (float)(-m[3] / q);   /* yy */
+    xpost_font_face_transform(face, mat);
+}
+
 static
 void _draw_bitmap(Xpost_Context *ctx,
                   Xpost_Object devdic,
@@ -376,8 +417,10 @@ int _show_char(Xpost_Context *ctx,
                  buffer, rows, width, pitch, pixel_mode,
                  *xpos + left, *ypos - top,
                  ncomp, comp1, comp2, comp3);
+    /* the face transform leaves the advance in y-up glyph space;
+       the pen advances in y-down device space */
     *xpos += advance_x >> 6;
-    *ypos += advance_y >> 6;
+    *ypos -= advance_y >> 6;
     *glyph_previous = glyph_index;
 #else
     (void)ctx;
@@ -489,6 +532,7 @@ int _show(Xpost_Context *ctx,
         XPOST_LOG_ERR("face is NULL");
         return invalidfont;
     }
+    _face_transform_from_ctm(ctx, gs, data.face);
     XPOST_LOG_INFO("loaded font data from dict");
 
     /* get a c-style nul-terminated string */
@@ -600,6 +644,7 @@ int _ashow(Xpost_Context *ctx,
         XPOST_LOG_ERR("face is NULL");
         return invalidfont;
     }
+    _face_transform_from_ctm(ctx, gs, data.face);
     XPOST_LOG_INFO("loaded font data from dict");
 
     /* get a c-style nul-terminated string */
@@ -715,6 +760,7 @@ int _widthshow(Xpost_Context *ctx,
         XPOST_LOG_ERR("face is NULL");
         return invalidfont;
     }
+    _face_transform_from_ctm(ctx, gs, data.face);
     XPOST_LOG_INFO("loaded font data from dict");
 
     /* get a c-style nul-terminated string */
@@ -835,6 +881,7 @@ int _awidthshow(Xpost_Context *ctx,
         XPOST_LOG_ERR("face is NULL");
         return invalidfont;
     }
+    _face_transform_from_ctm(ctx, gs, data.face);
     XPOST_LOG_INFO("loaded font data from dict");
 
     /* get a c-style nul-terminated string */
@@ -940,6 +987,7 @@ int _stringwidth(Xpost_Context *ctx,
         XPOST_LOG_ERR("face is NULL");
         return invalidfont;
     }
+    _face_transform_from_ctm(ctx, gs, data.face);
     XPOST_LOG_INFO("loaded font data from dict");
 
     /* get a c-style nul-terminated string */
@@ -996,9 +1044,11 @@ int _stringwidth(Xpost_Context *ctx,
 
     }
 
-    /* the advances accumulate in device space (the face is sized through
-       the CTM); stringwidth must report the distance in user space, so
-       map it back through the inverse of the CTM's linear part */
+    /* the advances accumulate in the face's y-up glyph space, sized and
+       oriented through the CTM; stringwidth must report the distance in
+       user space, so flip to the device's y-down convention and map back
+       through the inverse of the CTM's linear part */
+    ypos = -ypos;
     {
         Xpost_Object psmat = xpost_dict_get(ctx, gs, xpost_name_cons(ctx, "currmatrix"));
         if (xpost_object_get_type(psmat) == arraytype && psmat.comp_.sz == 6)
@@ -1082,6 +1132,7 @@ int _kshow(Xpost_Context *ctx,
         XPOST_LOG_ERR("face is NULL");
         return invalidfont;
     }
+    _face_transform_from_ctm(ctx, gs, data.face);
     XPOST_LOG_INFO("loaded font data from dict");
 
     /* get a c-style nul-terminated string */

--- a/src/lib/xpost_op_font.c
+++ b/src/lib/xpost_op_font.c
@@ -91,8 +91,36 @@ int _findfont(Xpost_Context *ctx,
     xpost_dict_put(ctx, fontdict, xpost_name_cons(ctx, "Private"), privatestr);
     xpost_dict_put(ctx, fontdict, xpost_name_cons(ctx, "FontName"), fontname);
 
-    /* initialize font data, with x-scale and y-scale set to 1 */
-    data.face = xpost_font_face_new_from_name(fname);
+    /* initialize font data, with x-scale and y-scale set to 1.
+       Faces are cached per name: each face maps the font file and
+       holds FreeType state, so creating one per findfont grows the
+       process by a mapping per lookup. The face is shared between
+       font dictionaries exactly as a FontDirectory-cached dictionary
+       already shares it. */
+    {
+        static struct { char *name; void *face; } face_cache[32];
+        static int face_cache_n = 0;
+        int fi;
+        data.face = NULL;
+        for (fi = 0; fi < face_cache_n; fi++)
+        {
+            if (strcmp(face_cache[fi].name, fname) == 0)
+            {
+                data.face = face_cache[fi].face;
+                break;
+            }
+        }
+        if (data.face == NULL)
+        {
+            data.face = xpost_font_face_new_from_name(fname);
+            if (data.face != NULL && face_cache_n < 32)
+            {
+                face_cache[face_cache_n].name = strdup(fname);
+                face_cache[face_cache_n].face = data.face;
+                face_cache_n++;
+            }
+        }
+    }
     if (data.face == NULL){
         free(fname);
         return invalidfont;

--- a/src/lib/xpost_op_font.c
+++ b/src/lib/xpost_op_font.c
@@ -968,6 +968,32 @@ int _stringwidth(Xpost_Context *ctx,
 
     }
 
+    /* the advances accumulate in device space (the face is sized through
+       the CTM); stringwidth must report the distance in user space, so
+       map it back through the inverse of the CTM's linear part */
+    {
+        Xpost_Object psmat = xpost_dict_get(ctx, gs, xpost_name_cons(ctx, "currmatrix"));
+        if (xpost_object_get_type(psmat) == arraytype && psmat.comp_.sz == 6)
+        {
+            real m[4], det;
+            int i;
+            for (i = 0; i < 4; i++)
+            {
+                Xpost_Object el = xpost_array_get(ctx, psmat, i);
+                m[i] = xpost_object_get_type(el) == realtype ? el.real_.val
+                     : (real)el.int_.val;
+            }
+            det = m[0] * m[3] - m[1] * m[2];
+            if (det != 0)
+            {
+                real ux = (m[3] * xpos - m[2] * ypos) / det;
+                real uy = (-m[1] * xpos + m[0] * ypos) / det;
+                xpos = ux;
+                ypos = uy;
+            }
+        }
+    }
+
     xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(xpos));
     xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(ypos));
 

--- a/src/lib/xpost_op_font.c
+++ b/src/lib/xpost_op_font.c
@@ -375,7 +375,6 @@ int _show_char(Xpost_Context *ctx,
                real *xpos,
                real *ypos,
                unsigned int ch,
-               unsigned int *glyph_previous,
                int ncomp,
                Xpost_Object comp1,
                Xpost_Object comp2,
@@ -417,7 +416,6 @@ int _show_char(Xpost_Context *ctx,
        (truncating each glyph's advance drifts the line's length) */
     *xpos += (real)(advance_x / 65536.0);
     *ypos -= (real)(advance_y / 65536.0);
-    *glyph_previous = glyph_index;
 #else
     (void)ctx;
     (void)devdic;
@@ -426,7 +424,6 @@ int _show_char(Xpost_Context *ctx,
     (void)xpos;
     (void)ypos;
     (void)ch;
-    (void)glyph_previous;
     (void)ncomp;
     (void)comp1;
     (void)comp2;
@@ -497,7 +494,6 @@ int _show(Xpost_Context *ctx,
     Xpost_Object finalize;
     int ret;
 
-    unsigned int glyph_previous;
 
     /* load the graphicsdict, current graphics state, and current font */
     userdict = xpost_stack_bottomup_fetch(ctx->lo, ctx->ds, 2);
@@ -570,9 +566,8 @@ int _show(Xpost_Context *ctx,
     xpost_stack_push(ctx->lo, ctx->es, finalize);
 
     /* render text in char *cstr  with font data  at pen position xpos ypos */
-    glyph_previous = 0;
     for (ch = cstr; *ch; ch++) {
-        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous,
+        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, (unsigned char)*ch,
                 ncomp, comp1, comp2, comp3);
     }
 
@@ -607,7 +602,6 @@ int _ashow(Xpost_Context *ctx,
     Xpost_Object finalize;
     int ret;
 
-    unsigned int glyph_previous;
 
     /* load the graphicsdict, current graphics state, and current font */
     userdict = xpost_stack_bottomup_fetch(ctx->lo, ctx->ds, 2);
@@ -680,10 +674,9 @@ int _ashow(Xpost_Context *ctx,
     xpost_stack_push(ctx->lo, ctx->es, finalize);
 
     /* render text in char *cstr  with font data  at pen position xpos ypos */
-    glyph_previous = 0;
     for (ch = cstr; *ch; ch++)
     {
-        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous,
+        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, (unsigned char)*ch,
                    ncomp, comp1, comp2, comp3);
         xpos += dx.real_.val;
         ypos += dy.real_.val;
@@ -721,7 +714,6 @@ int _widthshow(Xpost_Context *ctx,
     Xpost_Object finalize;
     int ret;
 
-    unsigned int glyph_previous;
 
     /* load the graphicsdict, current graphics state, and current font */
     userdict = xpost_stack_bottomup_fetch(ctx->lo, ctx->ds, 2);
@@ -794,12 +786,11 @@ int _widthshow(Xpost_Context *ctx,
     xpost_stack_push(ctx->lo, ctx->es, finalize);
 
     /* render text in char *cstr  with font data  at pen position xpos ypos */
-    glyph_previous = 0;
     for (ch = cstr; *ch; ch++)
     {
-        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous,
+        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, (unsigned char)*ch,
                    ncomp, comp1, comp2, comp3);
-        if (*ch == charcode.int_.val)
+        if ((unsigned char)*ch == charcode.int_.val)
         {
             xpos += cx.real_.val;
             ypos += cy.real_.val;
@@ -840,7 +831,6 @@ int _awidthshow(Xpost_Context *ctx,
     Xpost_Object finalize;
     int ret;
 
-    unsigned int glyph_previous;
 
     /* load the graphicsdict, current graphics state, and current font */
     userdict = xpost_stack_bottomup_fetch(ctx->lo, ctx->ds, 2);
@@ -913,14 +903,13 @@ int _awidthshow(Xpost_Context *ctx,
     xpost_stack_push(ctx->lo, ctx->es, finalize);
 
     /* render text in char *cstr  with font data  at pen position xpos ypos */
-    glyph_previous = 0;
     for (ch = cstr; *ch; ch++)
     {
-        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous,
+        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, (unsigned char)*ch,
                 ncomp, comp1, comp2, comp3);
         xpos += dx.real_.val;
         ypos += dy.real_.val;
-        if (*ch == charcode.int_.val)
+        if ((unsigned char)*ch == charcode.int_.val)
         {
             xpos += cx.real_.val;
             ypos += cy.real_.val;
@@ -948,6 +937,7 @@ int _stringwidth(Xpost_Context *ctx,
     char *cstr;
     real xpos = 0, ypos = 0;
     char *ch;
+
 
     /* load the graphicsdict, current graphics state, and current font */
     userdict = xpost_stack_bottomup_fetch(ctx->lo, ctx->ds, 2);
@@ -982,7 +972,7 @@ int _stringwidth(Xpost_Context *ctx,
        render text in char *cstr  with font data  at pen position xpos ypos */
     for (ch = cstr; *ch; ch++)
     {
-        /* _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous,
+        /* _show_char(ctx, devdic, putpix, data, &xpos, &ypos, (unsigned char)*ch,
                 ncomp, comp1, comp2, comp3); */
 
 #ifdef HAVE_FREETYPE2
@@ -997,7 +987,7 @@ int _stringwidth(Xpost_Context *ctx,
         long advance_x;
         long advance_y;
 
-        glyph_index = xpost_font_face_glyph_index_get(data.face, *ch);
+        glyph_index = xpost_font_face_glyph_index_get(data.face, (unsigned char)*ch);
         if (!xpost_font_face_glyph_render(data.face, glyph_index))
             return unregistered;
         xpost_font_face_glyph_buffer_get(data.face, &buffer, &rows, &width, &pitch, &pixel_mode, &left, &top, &advance_x, &advance_y);
@@ -1070,7 +1060,6 @@ int _kshow(Xpost_Context *ctx,
     Xpost_Object finalize;
     int ret;
 
-    unsigned int glyph_previous;
 
     (void) &proc;
     /* load the graphicsdict, current graphics state, and current font */
@@ -1144,10 +1133,9 @@ int _kshow(Xpost_Context *ctx,
     xpost_stack_push(ctx->lo, ctx->es, finalize);
 
     /* render text in char *cstr  with font data  at pen position xpos ypos */
-    glyph_previous = 0;
     for (ch = cstr; *ch; ch++)
     {
-        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous,
+        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, (unsigned char)*ch,
                 ncomp, comp1, comp2, comp3);
     }
 

--- a/src/lib/xpost_op_font.c
+++ b/src/lib/xpost_op_font.c
@@ -376,7 +376,6 @@ int _show_char(Xpost_Context *ctx,
                real *ypos,
                unsigned int ch,
                unsigned int *glyph_previous,
-               int has_kerning,
                int ncomp,
                Xpost_Object comp1,
                Xpost_Object comp2,
@@ -394,33 +393,30 @@ int _show_char(Xpost_Context *ctx,
     long advance_x;
     long advance_y;
 
+    /* show does not kern: pair adjustment in PostScript is the
+       program's business (kshow, ashow), and the reference
+       interpreter advances by the glyph widths alone */
     glyph_index = xpost_font_face_glyph_index_get(data.face, ch);
-    //TODO check fontdict's /AutoKern bool
-    if (has_kerning && *glyph_previous && (glyph_index > 0))
-    {
-        long delta_x;
-        long delta_y;
-
-        if (xpost_font_face_kerning_delta_get(data.face, *glyph_previous, glyph_index,
-                                              &delta_x, &delta_y))
-        {
-            *xpos += delta_x >> 6;
-            *ypos += delta_y >> 6;
-        }
-    }
     if (!xpost_font_face_glyph_render(data.face, glyph_index))
         return 0;
     xpost_font_face_glyph_buffer_get(data.face,
                                      &buffer, &rows, &width, &pitch, &pixel_mode,
                                      &left, &top, &advance_x, &advance_y);
+    /* the pen rides at fractional device positions but the glyph
+       bitmap sits on the pixel grid: place it at the nearest
+       pixel, not the floor, so a pen an epsilon shy of a pixel
+       boundary (the linear advance's 16.16 quantization) lands
+       where exact arithmetic would put it */
     _draw_bitmap(ctx, devdic, putpix,
                  buffer, rows, width, pitch, pixel_mode,
-                 *xpos + left, *ypos - top,
+                 (int)floor(*xpos + left + 0.5),
+                 (int)floor(*ypos - top + 0.5),
                  ncomp, comp1, comp2, comp3);
-    /* the face transform leaves the advance in y-up glyph space;
-       the pen advances in y-down device space */
-    *xpos += advance_x >> 6;
-    *ypos -= advance_y >> 6;
+    /* the face transform leaves the advance in y-up glyph space; the
+       pen advances in y-down device space, keeping the fractional part
+       (truncating each glyph's advance drifts the line's length) */
+    *xpos += (real)(advance_x / 65536.0);
+    *ypos -= (real)(advance_y / 65536.0);
     *glyph_previous = glyph_index;
 #else
     (void)ctx;
@@ -431,7 +427,6 @@ int _show_char(Xpost_Context *ctx,
     (void)ypos;
     (void)ch;
     (void)glyph_previous;
-    (void)has_kerning;
     (void)ncomp;
     (void)comp1;
     (void)comp2;
@@ -502,7 +497,6 @@ int _show(Xpost_Context *ctx,
     Xpost_Object finalize;
     int ret;
 
-    int has_kerning;
     unsigned int glyph_previous;
 
     /* load the graphicsdict, current graphics state, and current font */
@@ -576,10 +570,9 @@ int _show(Xpost_Context *ctx,
     xpost_stack_push(ctx->lo, ctx->es, finalize);
 
     /* render text in char *cstr  with font data  at pen position xpos ypos */
-    has_kerning = xpost_font_face_kerning_has(data.face);
     glyph_previous = 0;
     for (ch = cstr; *ch; ch++) {
-        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous, has_kerning,
+        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous,
                 ncomp, comp1, comp2, comp3);
     }
 
@@ -614,7 +607,6 @@ int _ashow(Xpost_Context *ctx,
     Xpost_Object finalize;
     int ret;
 
-    int has_kerning;
     unsigned int glyph_previous;
 
     /* load the graphicsdict, current graphics state, and current font */
@@ -688,11 +680,10 @@ int _ashow(Xpost_Context *ctx,
     xpost_stack_push(ctx->lo, ctx->es, finalize);
 
     /* render text in char *cstr  with font data  at pen position xpos ypos */
-    has_kerning = xpost_font_face_kerning_has(data.face);
     glyph_previous = 0;
     for (ch = cstr; *ch; ch++)
     {
-        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous, has_kerning,
+        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous,
                    ncomp, comp1, comp2, comp3);
         xpos += dx.real_.val;
         ypos += dy.real_.val;
@@ -730,7 +721,6 @@ int _widthshow(Xpost_Context *ctx,
     Xpost_Object finalize;
     int ret;
 
-    int has_kerning;
     unsigned int glyph_previous;
 
     /* load the graphicsdict, current graphics state, and current font */
@@ -804,11 +794,10 @@ int _widthshow(Xpost_Context *ctx,
     xpost_stack_push(ctx->lo, ctx->es, finalize);
 
     /* render text in char *cstr  with font data  at pen position xpos ypos */
-    has_kerning = xpost_font_face_kerning_has(data.face);
     glyph_previous = 0;
     for (ch = cstr; *ch; ch++)
     {
-        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous, has_kerning,
+        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous,
                    ncomp, comp1, comp2, comp3);
         if (*ch == charcode.int_.val)
         {
@@ -851,7 +840,6 @@ int _awidthshow(Xpost_Context *ctx,
     Xpost_Object finalize;
     int ret;
 
-    int has_kerning;
     unsigned int glyph_previous;
 
     /* load the graphicsdict, current graphics state, and current font */
@@ -925,11 +913,10 @@ int _awidthshow(Xpost_Context *ctx,
     xpost_stack_push(ctx->lo, ctx->es, finalize);
 
     /* render text in char *cstr  with font data  at pen position xpos ypos */
-    has_kerning = xpost_font_face_kerning_has(data.face);
     glyph_previous = 0;
     for (ch = cstr; *ch; ch++)
     {
-        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous, has_kerning,
+        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous,
                 ncomp, comp1, comp2, comp3);
         xpos += dx.real_.val;
         ypos += dy.real_.val;
@@ -962,9 +949,6 @@ int _stringwidth(Xpost_Context *ctx,
     real xpos = 0, ypos = 0;
     char *ch;
 
-    int has_kerning;
-    unsigned int glyph_previous;
-
     /* load the graphicsdict, current graphics state, and current font */
     userdict = xpost_stack_bottomup_fetch(ctx->lo, ctx->ds, 2);
     if (xpost_object_get_type(userdict) != dicttype)
@@ -996,11 +980,9 @@ int _stringwidth(Xpost_Context *ctx,
 
     /* do everything BUT
        render text in char *cstr  with font data  at pen position xpos ypos */
-    has_kerning = xpost_font_face_kerning_has(data.face);
-    glyph_previous = 0;
     for (ch = cstr; *ch; ch++)
     {
-        /* _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous, has_kerning,
+        /* _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous,
                 ncomp, comp1, comp2, comp3); */
 
 #ifdef HAVE_FREETYPE2
@@ -1016,18 +998,6 @@ int _stringwidth(Xpost_Context *ctx,
         long advance_y;
 
         glyph_index = xpost_font_face_glyph_index_get(data.face, *ch);
-        if (has_kerning && glyph_previous && (glyph_index > 0))
-        {
-            long delta_x;
-            long delta_y;
-
-            if (xpost_font_face_kerning_delta_get(data.face, glyph_previous, glyph_index,
-                                                  &delta_x, &delta_y))
-            {
-                xpos += delta_x >> 6;
-                ypos += delta_y >> 6;
-            }
-        }
         if (!xpost_font_face_glyph_render(data.face, glyph_index))
             return unregistered;
         xpost_font_face_glyph_buffer_get(data.face, &buffer, &rows, &width, &pitch, &pixel_mode, &left, &top, &advance_x, &advance_y);
@@ -1037,9 +1007,8 @@ int _stringwidth(Xpost_Context *ctx,
                 *xpos + left, *ypos - top,
                 ncomp, comp1, comp2, comp3);
                 */
-        xpos += advance_x >> 6;
-        ypos += advance_y >> 6;
-        glyph_previous = glyph_index;
+        xpos += (real)(advance_x / 65536.0);
+        ypos += (real)(advance_y / 65536.0);
 #endif
 
     }
@@ -1101,7 +1070,6 @@ int _kshow(Xpost_Context *ctx,
     Xpost_Object finalize;
     int ret;
 
-    int has_kerning;
     unsigned int glyph_previous;
 
     (void) &proc;
@@ -1176,11 +1144,10 @@ int _kshow(Xpost_Context *ctx,
     xpost_stack_push(ctx->lo, ctx->es, finalize);
 
     /* render text in char *cstr  with font data  at pen position xpos ypos */
-    has_kerning = xpost_font_face_kerning_has(data.face);
     glyph_previous = 0;
     for (ch = cstr; *ch; ch++)
     {
-        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous, has_kerning,
+        _show_char(ctx, devdic, putpix, data, &xpos, &ypos, *ch, &glyph_previous,
                 ncomp, comp1, comp2, comp3);
     }
 

--- a/src/lib/xpost_op_math.c
+++ b/src/lib/xpost_op_math.c
@@ -59,38 +59,36 @@
 #include "xpost_operator.h"
 #include "xpost_op_math.h"
 
-static
-int subwillunder(long x, long y);
+/* bounds of the postscript integer type, for overflow detection */
+static const long long integer_max =
+    (long long)(((unsigned long long)1 << (sizeof(integer)*8 - 1)) - 1);
+static const long long integer_min =
+    -(long long)(((unsigned long long)1 << (sizeof(integer)*8 - 1)) - 1) - 1;
 
 static
 int addwillover(long x,
                 long y)
 {
-    if (y == LONG_MIN) return x!=0;
-    if (y < 0) return subwillunder(x, -y);
-    if (x > LONG_MAX - y) return 1;
-    return 0;
+    if (y < 0) return x < integer_min - y;
+    return x > integer_max - y;
 }
 
 static
 int subwillunder(long x,
                  long y)
 {
-    if (y == LONG_MIN) return 1;
-    if (y < 0) return addwillover(x, -y);
-    if (x < LONG_MIN + y) return 1;
-    return 0;
+    if (y < 0) return x > integer_max + y;
+    return x < integer_min + y;
 }
 
 static
 int mulwillover(long x,
                 long y)
 {
-    if (x == 0||y == 0) return 0;
-    if (x < 0) x = -x;
-    if (y < 0) y = -y;
-    if (x > LONG_MAX / y) return 1;
-    return 0;
+    long long xx = x < 0 ? -(long long)x : (long long)x;
+    long long yy = y < 0 ? -(long long)y : (long long)y;
+    if (xx == 0 || yy == 0) return 0;
+    return xx > integer_max / yy;
 }
 
 /* num1 num2  add  sum

--- a/src/lib/xpost_op_math.c
+++ b/src/lib/xpost_op_math.c
@@ -41,9 +41,9 @@
 
 //#define PI (4.0 * atan(1.0))
 //double RAD_PER_DEG /* = PI / 180.0 */;
-//#define RAD_PER_DEG (M_PI / 180.0)
-//#define RAD_PER_DEG (3.14159 / 180.0)
-#define RAD_PER_DEG (0.0174533)
+/* the full-precision conversion: a truncated literal (0.0174533) skewed atan,
+   sin and cos off the PLRM examples (1 0 atan gave 89.99996, not 90.0) */
+#define RAD_PER_DEG (M_PI / 180.0)
 
 #include "xpost.h"
 #include "xpost_compat.h"

--- a/src/lib/xpost_op_math.c
+++ b/src/lib/xpost_op_math.c
@@ -317,6 +317,10 @@ static
 int Rsqrt (Xpost_Context *ctx,
             Xpost_Object x)
 {
+    /* PLRM: the operand must be nonnegative; a negative one is rangecheck,
+       not a silent NaN */
+    if (x.real_.val < 0.0)
+        return rangecheck;
     xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons((real)sqrt(x.real_.val)));
     return 0;
 }

--- a/src/lib/xpost_op_math.c
+++ b/src/lib/xpost_op_math.c
@@ -136,6 +136,14 @@ int Iidiv(Xpost_Context *ctx,
 {
     if (y.int_.val == 0)
         return undefinedresult;
+    /* INT_MIN / -1 overflows a two's-complement integer (a hardware fault on
+       some platforms); it exceeds the integer range, so yield the real quotient
+       the way an overflowing product does */
+    if (y.int_.val == -1 && x.int_.val == (-2147483647 - 1))
+    {
+        xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(-(real)x.int_.val));
+        return 0;
+    }
     xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons(x.int_.val / y.int_.val));
     return 0;
 }
@@ -147,6 +155,15 @@ int Imod(Xpost_Context *ctx,
          Xpost_Object x,
          Xpost_Object y)
 {
+    /* a zero divisor is undefinedresult (PLRM), not a hardware divide fault;
+       guard the INT_MIN % -1 overflow the same way idiv's quotient is guarded */
+    if (y.int_.val == 0)
+        return undefinedresult;
+    if (y.int_.val == -1)
+    {
+        xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons(0));
+        return 0;
+    }
     xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons(x.int_.val % y.int_.val));
     return 0;
 }

--- a/src/lib/xpost_op_matrix.c
+++ b/src/lib/xpost_op_matrix.c
@@ -468,9 +468,9 @@ int _mat_itransform(Xpost_Context *ctx,
     if (disc == 0)
         return undefinedresult;
     invdet = 1 / disc;
-    xres = (mat.yy * x.real_.val - mat.yx * y.real_.val +
-            mat.xy * mat.xz - mat.yy * mat.xz) * invdet;
-    yres = (-mat.xy * x.real_.val + mat.xx * y.real_.val +
+    xres = (mat.yy * x.real_.val - mat.xy * y.real_.val +
+            mat.xy * mat.yz - mat.yy * mat.xz) * invdet;
+    yres = (-mat.yx * x.real_.val + mat.xx * y.real_.val +
             mat.yx * mat.xz - mat.xx * mat.yz) * invdet;
     xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(xres));
     xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(yres));
@@ -507,8 +507,8 @@ int _mat_idtransform(Xpost_Context *ctx,
     if (disc == 0)
         return undefinedresult;
     invdet = 1 / disc;
-    xres = (mat.yy * x.real_.val - mat.yx * y.real_.val) * invdet;
-    yres = ( -mat.xy * x.real_.val + mat.xx * y.real_.val) * invdet;
+    xres = (mat.yy * x.real_.val - mat.xy * y.real_.val) * invdet;
+    yres = ( -mat.yx * x.real_.val + mat.xx * y.real_.val) * invdet;
     xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(xres));
     xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(yres));
     return 0;

--- a/src/lib/xpost_op_matrix.c
+++ b/src/lib/xpost_op_matrix.c
@@ -225,7 +225,9 @@ int _default_matrix(Xpost_Context *ctx,
 
     xpost_stack_push(ctx->lo, ctx->os, defmat);
     xpost_stack_push(ctx->lo, ctx->os, psmat);
-    xpost_stack_push(ctx->lo, ctx->es, xpost_object_cvx(xpost_name_cons(ctx, "copy")));
+    /* schedule the operator itself: a name would resolve through the
+       dict stack and could be captured by a user definition */
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons(ctx, "copy", NULL, 0, 0));
     return 0;
 }
 
@@ -239,7 +241,9 @@ int _current_matrix(Xpost_Context *ctx,
     ctm = _get_ctm(ctx);
     xpost_stack_push(ctx->lo, ctx->os, ctm);
     xpost_stack_push(ctx->lo, ctx->os, psmat);
-    xpost_stack_push(ctx->lo, ctx->es, xpost_object_cvx(xpost_name_cons(ctx, "copy")));
+    /* schedule the operator itself: a name would resolve through the
+       dict stack and could be captured by a user definition */
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons(ctx, "copy", NULL, 0, 0));
     return 0;
 }
 
@@ -253,8 +257,12 @@ int _set_matrix(Xpost_Context *ctx,
     ctm = _get_ctm(ctx);
     xpost_stack_push(ctx->lo, ctx->os, psmat);
     xpost_stack_push(ctx->lo, ctx->os, ctm);
-    xpost_stack_push(ctx->lo, ctx->es, xpost_object_cvx(xpost_name_cons(ctx, "pop")));
-    xpost_stack_push(ctx->lo, ctx->es, xpost_object_cvx(xpost_name_cons(ctx, "copy")));
+    /* schedule the operator itself: a name would resolve through the
+       dict stack and could be captured by a user definition */
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons(ctx, "pop", NULL, 0, 0));
+    /* schedule the operator itself: a name would resolve through the
+       dict stack and could be captured by a user definition */
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons(ctx, "copy", NULL, 0, 0));
     return 0;
 }
 
@@ -271,7 +279,9 @@ int _translate(Xpost_Context *ctx,
     xpost_matrix_translate(&mat, xt.real_.val, yt.real_.val);
     _xmat2psmat(ctx, &mat, psmat);
     xpost_stack_push(ctx->lo, ctx->os, psmat);
-    xpost_stack_push(ctx->lo, ctx->es, xpost_object_cvx(xpost_name_cons(ctx, "concat")));
+    /* schedule the operator itself: a name would resolve through the
+       dict stack and could be captured by a user definition */
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons(ctx, "concat", NULL, 0, 0));
     return 0;
 }
 
@@ -303,7 +313,9 @@ int _scale(Xpost_Context *ctx,
     xpost_matrix_scale(&mat, xs.real_.val, ys.real_.val);
     _xmat2psmat(ctx, &mat, psmat);
     xpost_stack_push(ctx->lo, ctx->os, psmat);
-    xpost_stack_push(ctx->lo, ctx->es, xpost_object_cvx(xpost_name_cons(ctx, "concat")));
+    /* schedule the operator itself: a name would resolve through the
+       dict stack and could be captured by a user definition */
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons(ctx, "concat", NULL, 0, 0));
     return 0;
 }
 
@@ -334,7 +346,9 @@ int _rotate(Xpost_Context *ctx,
     xpost_matrix_rotate(&mat, angle.real_.val * RAD_PER_DEG);
     _xmat2psmat(ctx, &mat, psmat);
     xpost_stack_push(ctx->lo, ctx->os, psmat);
-    xpost_stack_push(ctx->lo, ctx->es, xpost_object_cvx(xpost_name_cons(ctx, "concat")));
+    /* schedule the operator itself: a name would resolve through the
+       dict stack and could be captured by a user definition */
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons(ctx, "concat", NULL, 0, 0));
     return 0;
 }
 

--- a/src/lib/xpost_op_matrix.c
+++ b/src/lib/xpost_op_matrix.c
@@ -58,7 +58,8 @@
 #include "xpost_op_matrix.h"
 
 //#define RAD_PER_DEG (M_PI / 180.0)
-#define RAD_PER_DEG (0.0174533)
+/* full precision: a truncated literal skewed rotate off the axis angles */
+#define RAD_PER_DEG (M_PI / 180.0)
 
 // TODO Factor out name_cons() calls.
 

--- a/src/lib/xpost_op_matrix.c
+++ b/src/lib/xpost_op_matrix.c
@@ -125,13 +125,20 @@ int _psmat2xmat(Xpost_Context *ctx,
 }
 
 static
-void _xmat2psmat(Xpost_Context *ctx,
-                 Xpost_Matrix *m,
-                 Xpost_Object psm)
+int _xmat2psmat(Xpost_Context *ctx,
+                Xpost_Matrix *m,
+                Xpost_Object psm)
 {
     Xpost_Object arr[6];
-    Xpost_Memory_File *mem = xpost_context_select_memory(ctx, psm);
-    unsigned int ent = xpost_object_get_ent(psm);
+    Xpost_Memory_File *mem;
+    unsigned int ent;
+
+    /* the bulk write below stores six objects at once; a destination shorter
+       than six would overrun its storage in the arena (PLRM: rangecheck) */
+    if (xpost_object_get_type(psm) != arraytype || psm.comp_.sz != 6)
+        return rangecheck;
+    mem = xpost_context_select_memory(ctx, psm);
+    ent = xpost_object_get_ent(psm);
 
     arr[0] = xpost_real_cons(m->xx);
     arr[1] = xpost_real_cons(m->yx);
@@ -146,6 +153,7 @@ void _xmat2psmat(Xpost_Context *ctx,
     if (!xpost_save_ent_is_saved(mem, ent))
         xpost_save_save_ent(mem, arraytype, psm.comp_.sz, ent);
     xpost_memory_put(mem, ent, 0, sizeof arr, arr);
+    return 0;
 }
 
 /* forward decl's */
@@ -171,7 +179,7 @@ int _ident_matrix(Xpost_Context *ctx,
 {
     Xpost_Matrix mat;
     xpost_matrix_identity(&mat);
-    _xmat2psmat(ctx, &mat, psmat);
+    if (_xmat2psmat(ctx, &mat, psmat)) return rangecheck;
     xpost_stack_push(ctx->lo, ctx->os, psmat);
     return 0;
 }
@@ -282,7 +290,7 @@ int _translate(Xpost_Context *ctx,
     Xpost_Object psmat;
     psmat = xpost_object_cvlit(xpost_array_cons(ctx, 6));
     xpost_matrix_translate(&mat, xt.real_.val, yt.real_.val);
-    _xmat2psmat(ctx, &mat, psmat);
+    if (_xmat2psmat(ctx, &mat, psmat)) return rangecheck;
     xpost_stack_push(ctx->lo, ctx->os, psmat);
     /* schedule the operator itself: a name would resolve through the
        dict stack and could be captured by a user definition */
@@ -300,7 +308,7 @@ int _mat_translate(Xpost_Context *ctx,
 {
     Xpost_Matrix mat;
     xpost_matrix_translate(&mat, xt.real_.val, yt.real_.val);
-    _xmat2psmat(ctx, &mat, psmat);
+    if (_xmat2psmat(ctx, &mat, psmat)) return rangecheck;
     xpost_stack_push(ctx->lo, ctx->os, psmat);
     return 0;
 }
@@ -316,7 +324,7 @@ int _scale(Xpost_Context *ctx,
     Xpost_Object psmat;
     psmat = xpost_object_cvlit(xpost_array_cons(ctx, 6));
     xpost_matrix_scale(&mat, xs.real_.val, ys.real_.val);
-    _xmat2psmat(ctx, &mat, psmat);
+    if (_xmat2psmat(ctx, &mat, psmat)) return rangecheck;
     xpost_stack_push(ctx->lo, ctx->os, psmat);
     /* schedule the operator itself: a name would resolve through the
        dict stack and could be captured by a user definition */
@@ -334,7 +342,7 @@ int _mat_scale(Xpost_Context *ctx,
 {
     Xpost_Matrix mat;
     xpost_matrix_scale(&mat, xs.real_.val, ys.real_.val);
-    _xmat2psmat(ctx, &mat, psmat);
+    if (_xmat2psmat(ctx, &mat, psmat)) return rangecheck;
     xpost_stack_push(ctx->lo, ctx->os, psmat);
     return 0;
 }
@@ -349,7 +357,7 @@ int _rotate(Xpost_Context *ctx,
     Xpost_Object psmat;
     psmat = xpost_object_cvlit(xpost_array_cons(ctx, 6));
     xpost_matrix_rotate(&mat, angle.real_.val * RAD_PER_DEG);
-    _xmat2psmat(ctx, &mat, psmat);
+    if (_xmat2psmat(ctx, &mat, psmat)) return rangecheck;
     xpost_stack_push(ctx->lo, ctx->os, psmat);
     /* schedule the operator itself: a name would resolve through the
        dict stack and could be captured by a user definition */
@@ -366,7 +374,7 @@ int _mat_rotate(Xpost_Context *ctx,
 {
     Xpost_Matrix mat;
     xpost_matrix_rotate(&mat, (real)(RAD_PER_DEG * angle.real_.val));
-    _xmat2psmat(ctx, &mat, psmat);
+    if (_xmat2psmat(ctx, &mat, psmat)) return rangecheck;
     xpost_stack_push(ctx->lo, ctx->os, psmat);
     return 0;
 }
@@ -389,7 +397,7 @@ int _concat(Xpost_Context *ctx,
     if (_psmat2xmat(ctx, psctm, &ctm)) return rangecheck;
     xpost_matrix_mult(&ctm, &mat, &result);
     //replace CTM
-    _xmat2psmat(ctx, &result, psctm);
+    if (_xmat2psmat(ctx, &result, psctm)) return rangecheck;
     return 0;
 }
 
@@ -405,7 +413,7 @@ int _concat_matrix(Xpost_Context *ctx,
     if (_psmat2xmat(ctx, psmat1, &mat1)) return rangecheck;
     if (_psmat2xmat(ctx, psmat2, &mat2)) return rangecheck;
     xpost_matrix_mult(&mat2, &mat1, &mat3);
-    _xmat2psmat(ctx, &mat3, psmat3);
+    if (_xmat2psmat(ctx, &mat3, psmat3)) return rangecheck;
     xpost_stack_push(ctx->lo, ctx->os, psmat3);
     return 0;
 }
@@ -567,7 +575,7 @@ int _invert_matrix(Xpost_Context *ctx,
     mat2.yy = mat1.xx * invdet;
     mat2.xz = (mat1.xy * mat1.yz - mat1.yy * mat1.xz) * invdet;
     mat2.yz = (mat1.yx * mat1.xz - mat1.xx * mat1.yz) * invdet;
-    _xmat2psmat(ctx, &mat2, psmat2);
+    if (_xmat2psmat(ctx, &mat2, psmat2)) return rangecheck;
     xpost_stack_push(ctx->lo, ctx->os, psmat2);
     return 0;
 }

--- a/src/lib/xpost_op_matrix.c
+++ b/src/lib/xpost_op_matrix.c
@@ -81,12 +81,16 @@ Xpost_Object _get_ctm(Xpost_Context *ctx)
 }
 
 static
-void _psmat2xmat(Xpost_Context *ctx,
+int _psmat2xmat(Xpost_Context *ctx,
                  Xpost_Object psm,
                  Xpost_Matrix *m)
 {
     Xpost_Object arr[6];
     int i;
+    /* the matrix operand must be a six-element array; a shorter one would make
+       the bulk read below run off the end of its storage (PLRM: rangecheck) */
+    if (xpost_object_get_type(psm) != arraytype || psm.comp_.sz != 6)
+        return rangecheck;
     xpost_memory_get(xpost_context_select_memory(ctx, psm),
             xpost_object_get_ent(psm), 0, sizeof arr, arr);
     for (i = 0; i < 6; i++)
@@ -100,6 +104,7 @@ void _psmat2xmat(Xpost_Context *ctx,
     m->yy = arr[3].real_.val;
     m->xz = arr[4].real_.val;
     m->yz = arr[5].real_.val;
+    return 0;
 
     /*
     Xpost_Object el;
@@ -376,11 +381,11 @@ int _concat(Xpost_Context *ctx,
     Xpost_Matrix ctm;
     Xpost_Matrix result;
 
-    _psmat2xmat(ctx, psmat, &mat);
+    if (_psmat2xmat(ctx, psmat, &mat)) return rangecheck;
     //fetch CTM from graphics state
     psctm = _get_ctm(ctx);
     //xpost_matrix_mult
-    _psmat2xmat(ctx, psctm, &ctm);
+    if (_psmat2xmat(ctx, psctm, &ctm)) return rangecheck;
     xpost_matrix_mult(&ctm, &mat, &result);
     //replace CTM
     _xmat2psmat(ctx, &result, psctm);
@@ -396,8 +401,8 @@ int _concat_matrix(Xpost_Context *ctx,
                    Xpost_Object psmat3)
 {
     Xpost_Matrix mat1, mat2, mat3;
-    _psmat2xmat(ctx, psmat1, &mat1);
-    _psmat2xmat(ctx, psmat2, &mat2);
+    if (_psmat2xmat(ctx, psmat1, &mat1)) return rangecheck;
+    if (_psmat2xmat(ctx, psmat2, &mat2)) return rangecheck;
     xpost_matrix_mult(&mat2, &mat1, &mat3);
     _xmat2psmat(ctx, &mat3, psmat3);
     xpost_stack_push(ctx->lo, ctx->os, psmat3);
@@ -414,7 +419,7 @@ int _mat_transform(Xpost_Context *ctx,
 {
     Xpost_Matrix mat;
     real xres, yres;
-    _psmat2xmat(ctx, psmat, &mat);
+    if (_psmat2xmat(ctx, psmat, &mat)) return rangecheck;
     xres = mat.xx * x.real_.val + mat.xy * y.real_.val + mat.xz;
     yres = mat.yx * x.real_.val + mat.yy * y.real_.val + mat.yz;
     xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(xres));
@@ -444,7 +449,7 @@ int _mat_dtransform(Xpost_Context *ctx,
 {
     Xpost_Matrix mat;
     real xres, yres;
-    _psmat2xmat(ctx, psmat, &mat);
+    if (_psmat2xmat(ctx, psmat, &mat)) return rangecheck;
     xres = mat.xx * x.real_.val + mat.xy * y.real_.val;
     yres = mat.yx * x.real_.val + mat.yy * y.real_.val;
     xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(xres));
@@ -476,7 +481,7 @@ int _mat_itransform(Xpost_Context *ctx,
     real xres, yres;
     real disc;
     real invdet;
-    _psmat2xmat(ctx, psmat, &mat);
+    if (_psmat2xmat(ctx, psmat, &mat)) return rangecheck;
     disc = mat.xx * mat.yy - mat.yx * mat.xy;
     if (disc == 0)
         return undefinedresult;
@@ -515,7 +520,7 @@ int _mat_idtransform(Xpost_Context *ctx,
     real xres, yres;
     real disc;
     real invdet;
-    _psmat2xmat(ctx, psmat, &mat);
+    if (_psmat2xmat(ctx, psmat, &mat)) return rangecheck;
     disc = mat.xx * mat.yy - mat.yx * mat.xy;
     if (disc == 0)
         return undefinedresult;
@@ -550,7 +555,7 @@ int _invert_matrix(Xpost_Context *ctx,
     Xpost_Matrix mat1, mat2;
     real disc;
     real invdet;
-    _psmat2xmat(ctx, psmat1, &mat1);
+    if (_psmat2xmat(ctx, psmat1, &mat1)) return rangecheck;
     disc = mat1.xx * mat1.yy - mat1.yx * mat1.xy;
     if (disc == 0)
         return undefinedresult;

--- a/src/lib/xpost_op_matrix.c
+++ b/src/lib/xpost_op_matrix.c
@@ -51,6 +51,7 @@
 #include "xpost_string.h"
 #include "xpost_dict.h"
 #include "xpost_array.h"
+#include "xpost_save.h"
 
 //#include "xpost_interpreter.h"
 #include "xpost_operator.h"
@@ -123,6 +124,8 @@ void _xmat2psmat(Xpost_Context *ctx,
                  Xpost_Object psm)
 {
     Xpost_Object arr[6];
+    Xpost_Memory_File *mem = xpost_context_select_memory(ctx, psm);
+    unsigned int ent = xpost_object_get_ent(psm);
 
     arr[0] = xpost_real_cons(m->xx);
     arr[1] = xpost_real_cons(m->yx);
@@ -130,17 +133,13 @@ void _xmat2psmat(Xpost_Context *ctx,
     arr[3] = xpost_real_cons(m->yy);
     arr[4] = xpost_real_cons(m->xz);
     arr[5] = xpost_real_cons(m->yz);
-    xpost_memory_put(xpost_context_select_memory(ctx, psm),
-            xpost_object_get_ent(psm), 0, sizeof arr, arr);
-
-    /*
-    xpost_array_put(ctx, psm, 0, xpost_real_cons(m->xx));
-    xpost_array_put(ctx, psm, 1, xpost_real_cons(m->yx));
-    xpost_array_put(ctx, psm, 2, xpost_real_cons(m->xy));
-    xpost_array_put(ctx, psm, 3, xpost_real_cons(m->yy));
-    xpost_array_put(ctx, psm, 4, xpost_real_cons(m->xz));
-    xpost_array_put(ctx, psm, 5, xpost_real_cons(m->yz));
-    */
+    /* Back the array up for save/restore before the bulk write, the way
+       xpost_array_put does per element. Without this a matrix modified inside a
+       save -- the CTM, under scale/concat/rotate -- is not reverted by the
+       matching restore, so a transform set inside a save leaks past it. */
+    if (!xpost_save_ent_is_saved(mem, ent))
+        xpost_save_save_ent(mem, arraytype, psm.comp_.sz, ent);
+    xpost_memory_put(mem, ent, 0, sizeof arr, arr);
 }
 
 /* forward decl's */

--- a/src/lib/xpost_op_misc.c
+++ b/src/lib/xpost_op_misc.c
@@ -75,6 +75,7 @@ Xpost_Object bind(Xpost_Context *ctx,
         {
             default: break;
             case nametype:
+                if (!xpost_object_is_exe(t)) break; /* bind only replaces executable names */
                 z = xpost_stack_count(ctx->lo, ctx->ds);
                 for (j = 0; j < z; j++) {
                     d = xpost_stack_topdown_fetch(ctx->lo, ctx->ds, j);

--- a/src/lib/xpost_op_misc.c
+++ b/src/lib/xpost_op_misc.c
@@ -62,12 +62,41 @@
 #include "xpost_op_dict.h"
 #include "xpost_op_misc.h"
 
+/* the procedures already walked in this bind, so a procedure that
+   reaches itself -- directly or through others -- binds once and
+   terminates: access flags ride on the reference, not the value, so
+   marking the copy in hand cannot break the cycle */
+typedef struct
+{
+    unsigned int *ents;
+    int n, cap;
+} Bind_Seen;
+
 static
 Xpost_Object bind(Xpost_Context *ctx,
-                  Xpost_Object p)
+                  Xpost_Object p,
+                  Bind_Seen *seen)
 {
     Xpost_Object t, d;
+    unsigned int ent;
     int i, j, z;
+
+    ent = xpost_object_get_ent(p);
+    for (i = 0; i < seen->n; i++)
+        if (seen->ents[i] == ent)
+            return xpost_object_set_access(ctx, p, XPOST_OBJECT_TAG_ACCESS_READ_ONLY);
+    if (seen->n == seen->cap)
+    {
+        int ncap = seen->cap ? seen->cap * 2 : 64;
+        unsigned int *nents = realloc(seen->ents, (size_t)ncap * sizeof(*nents));
+
+        if (!nents)
+            return xpost_object_set_access(ctx, p, XPOST_OBJECT_TAG_ACCESS_READ_ONLY);
+        seen->ents = nents;
+        seen->cap = ncap;
+    }
+    seen->ents[seen->n++] = ent;
+
     for (i = 0; i < p.comp_.sz; i++)
     {
         t = xpost_array_get(ctx, p, i);
@@ -89,9 +118,13 @@ Xpost_Object bind(Xpost_Context *ctx,
                 }
                 break;
             case arraytype:
-                if (xpost_object_is_exe(t))
+                /* recursion reaches procedures with unrestricted
+                   access only (PLRM): an already-bound, read-only
+                   procedure keeps its finished contents */
+                if (xpost_object_is_exe(t)
+                 && xpost_object_get_access(ctx, t) >= XPOST_OBJECT_TAG_ACCESS_UNLIMITED)
                 {
-                    t = bind(ctx, t);
+                    t = bind(ctx, t, seen);
                     xpost_array_put(ctx, p, i, t);
                 }
         }
@@ -105,7 +138,12 @@ static
 int Pbind(Xpost_Context *ctx,
           Xpost_Object P)
 {
-    xpost_stack_push(ctx->lo, ctx->os, bind(ctx, P));
+    Bind_Seen seen;
+
+    seen.ents = NULL;
+    seen.n = seen.cap = 0;
+    xpost_stack_push(ctx->lo, ctx->os, bind(ctx, P, &seen));
+    free(seen.ents);
     return 0;
 }
 

--- a/src/lib/xpost_op_packedarray.c
+++ b/src/lib/xpost_op_packedarray.c
@@ -81,8 +81,14 @@ static
 int setpacking(Xpost_Context *ctx,
                Xpost_Object b)
 {
-    Xpost_Object sd = xpost_stack_bottomup_fetch(ctx->lo, ctx->ds, 0);
-    xpost_dict_put(ctx, sd, xpost_name_cons(ctx, "currentpacking"), b);
+    ctx->packing = (b.int_.val != 0);
+    return 0;
+}
+
+static
+int currentpacking(Xpost_Context *ctx)
+{
+    xpost_stack_push(ctx->lo, ctx->os, xpost_bool_cons(ctx->packing));
     return 0;
 }
 
@@ -99,8 +105,9 @@ int xpost_oper_init_packedarray_ops(Xpost_Context *ctx,
 
     op = xpost_operator_cons(ctx, "packedarray", (Xpost_Op_Func)packedarray, 1, 1, integertype);
     INSTALL;
-    xpost_dict_put(ctx, sd, xpost_name_cons(ctx, "currentpacking"), xpost_bool_cons(0));
     op = xpost_operator_cons(ctx, "setpacking", (Xpost_Op_Func)setpacking, 0, 1, booleantype);
+    INSTALL;
+    op = xpost_operator_cons(ctx, "currentpacking", (Xpost_Op_Func)currentpacking, 1, 0);
     INSTALL;
 
     /* xpost_dict_dump_memory (ctx->gl, sd); fflush(NULL);

--- a/src/lib/xpost_op_packedarray.c
+++ b/src/lib/xpost_op_packedarray.c
@@ -61,6 +61,12 @@ int packedarray(Xpost_Context *ctx,
 {
     int i;
     Xpost_Object a, v;
+
+    if (n.int_.val < 0)
+        return rangecheck;
+    if (n.int_.val > 65535) /* sz field is 16 bits; PLRM minimum limit */
+        return limitcheck;
+
     a = xpost_array_cons(ctx, n.int_.val);
     if (xpost_object_get_type(a) == nulltype)
         return VMerror;

--- a/src/lib/xpost_op_param.c
+++ b/src/lib/xpost_op_param.c
@@ -116,8 +116,8 @@ int globalvmstatus (Xpost_Context *ctx)
         return VMerror;
     }
     lev = xpost_stack_count(ctx->gl, vstk);
-    used = ctx->gl->used + ctx->gl->used;
-    max = ctx->gl->max + ctx->gl->max;
+    used = ctx->gl->used;
+    max = ctx->gl->max;
 
     if (!xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons(lev)))
         return stackoverflow;

--- a/src/lib/xpost_op_param.c
+++ b/src/lib/xpost_op_param.c
@@ -70,8 +70,12 @@ int vmreclaim (Xpost_Context *ctx, Xpost_Object I)
             if (ctx->garbage_collect_function(ctx->lo, 1, 0) == -1)
                 return VMerror;
             break;
-        case 2: /* perform immediate collection in local and global vm */
-            if (ctx->garbage_collect_function(ctx->gl, 1, 1) == -1)
+        case 2: /* local and global; global collection is disabled (see
+                   xpost_garbage_collect), so perform the local collection --
+                   passing the global mfile would collect nothing. Global
+                   objects cannot reference local ones, so the local sweep is
+                   complete on its own. */
+            if (ctx->garbage_collect_function(ctx->lo, 1, 0) == -1)
                 return VMerror;
             break;
     }

--- a/src/lib/xpost_op_path.c
+++ b/src/lib/xpost_op_path.c
@@ -72,7 +72,8 @@
  */
 
 //#define RAD_PER_DEG (M_PI / 180.0)
-#define RAD_PER_DEG (0.0174533)
+/* full precision: a truncated literal skewed arc endpoints off the axes */
+#define RAD_PER_DEG (M_PI / 180.0)
 
 /*name objects*/
 static Xpost_Object namegraphicsdict;
@@ -620,15 +621,32 @@ int _arc_append(Xpost_Context *ctx,
     if (fabs(a2 - a1) > 5760)
         a2 = a1 + dir * 5760;
 
+    /* snap an endpoint that lands a hair off a quadrant boundary onto it: the
+       tangent-point arithmetic behind arct/arcto leaves a right-angle corner's
+       start/end angle a shade off 90n, which would otherwise flip a floor() and
+       emit a full quadrant plus a sub-ulp sliver instead of one segment. The
+       tolerance is set from single-precision reals (typedef float real): one ulp
+       of a degree value near 90 is 90*2^-23 ~= 7.6e-6, so an angle within 1e-5
+       (just over one ulp) of 90n is a right angle blurred by float rounding, not
+       a distinct span. Anything a full ulp or more away is left to split. */
+    {
+        double q1 = floor(a1 / 90.0 + 0.5) * 90.0;
+        double q2 = floor(a2 / 90.0 + 0.5) * 90.0;
+        if (fabs(a1 - q1) < 1e-5) a1 = q1;
+        if (fabs(a2 - q2) < 1e-5) a2 = q2;
+    }
     cur = a1;
     b = dir > 0 ? (floor(a1 / 90) + 1) * 90 : (ceil(a1 / 90) - 1) * 90;
-    while (n < 65 && (dir > 0 ? b < a2 : b > a2))
+    /* tolerate a hair of floating-point slop at a quadrant boundary: a span
+       that ends exactly on 90n (a right-angle corner, common from arct) must
+       be one segment, not a full quadrant plus a sub-microdegree sliver */
+    while (n < 65 && (dir > 0 ? b < a2 - 1e-6 : b > a2 + 1e-6))
     {
         segs[n][0] = cur; segs[n][1] = b; n++;
         cur = b;
         b += dir * 90;
     }
-    if (fabs(a2 - cur) > 1e-9)
+    if (fabs(a2 - cur) > 1e-6)
     {
         segs[n][0] = cur; segs[n][1] = a2; n++;
     }

--- a/src/lib/xpost_op_path.c
+++ b/src/lib/xpost_op_path.c
@@ -548,33 +548,38 @@ static
 Xpost_Object _arc_start_proc;
 
 static
-int _arcbez(Xpost_Context *ctx,
-            Xpost_Object x, Xpost_Object y, Xpost_Object r,
-            Xpost_Object angle1, Xpost_Object angle2)
+Xpost_Object _arc_start_proc;
+
+/* Push one circular-arc segment's cubic Bezier onto the operand stack in
+   user-space coordinates, forward: the four points run from the angle1
+   end to the angle2 end (negative da sweeps clockwise). Push order is
+   x1 y1 x2 y2 x3 y3, ready for the curveto the caller schedules; the
+   control offsets follow the standard circular approximation. */
+static
+void _arcbezseg(Xpost_Context *ctx,
+                double cx, double cy, double r,
+                double a1, double a2)
 {
     Xpost_Matrix mat1, mat2, mat3;
     real da_2, sin_a, cos_a;
-    real x0, y0, x1, y1, x2, y2, x3, y3;
+    real x1, y1, x2, y2, x3, y3;
 
-    xpost_matrix_scale(&mat1, r.real_.val, r.real_.val);
-    xpost_matrix_translate(&mat2, x.real_.val, y.real_.val);
+    xpost_matrix_scale(&mat1, (real)r, (real)r);
+    xpost_matrix_translate(&mat2, (real)cx, (real)cy);
     xpost_matrix_mult(&mat2, &mat1, &mat3);
-    xpost_matrix_rotate(&mat2, (real)(((angle1.real_.val + angle2.real_.val) / 2.0) * RAD_PER_DEG));
+    xpost_matrix_rotate(&mat2, (real)(((a1 + a2) / 2.0) * RAD_PER_DEG));
     xpost_matrix_mult(&mat3, &mat2, &mat1);
 
-    da_2 = (real)(((angle2.real_.val - angle1.real_.val) / 2.0) * RAD_PER_DEG);
+    da_2 = (real)(((a2 - a1) / 2.0) * RAD_PER_DEG);
     sin_a = (real)sin(da_2);
     cos_a = (real)cos(da_2);
-    x0 = cos_a;
-    y0 = sin_a;
     x1 = (real)((4 - cos_a) / 3.0);
-    //y1 = - (((1 - cos_a) * (cos_a - 3)) / (3 * sin_a));
     y1 = (1 - x1*cos_a) / sin_a;
     x2 = x1;
-    y2 = -y1;
     x3 = cos_a;
-    y3 = -sin_a;
-    _transform(mat1, x0, y0, &x0, &y0);
+    y2 = y1;
+    y1 = -y1;
+    y3 = sin_a;
     _transform(mat1, x1, y1, &x1, &y1);
     _transform(mat1, x2, y2, &x2, &y2);
     _transform(mat1, x3, y3, &x3, &y3);
@@ -584,8 +589,63 @@ int _arcbez(Xpost_Context *ctx,
     xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(y2));
     xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(x3));
     xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(y3));
-    xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(x0));
-    xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(y0));
+}
+
+/* Append a circular arc counterclockwise (dir=1) or clockwise (dir=-1)
+   from a1 to a2, split at the quadrant boundaries as the reference
+   interpreter splits, emitted forward: the first point (at a1) reaches
+   the path through moveto-or-lineto and each segment through curveto,
+   leaving the current point at a2 as the language requires. The
+   scheduled operators transform the user-space coordinates through the
+   CTM as they run; the exec stack runs last-pushed first, so segments
+   are pushed in reverse. */
+static
+int _arc_append(Xpost_Context *ctx,
+                Xpost_Object x, Xpost_Object y, Xpost_Object r,
+                Xpost_Object angle1, Xpost_Object angle2, int dir)
+{
+    double cx = x.real_.val;
+    double cy = y.real_.val;
+    double rr = r.real_.val;
+    double a1 = angle1.real_.val;
+    double a2 = angle2.real_.val;
+    double segs[66][2];
+    double cur, b;
+    int n = 0, i;
+    real sx, sy;
+
+    if (dir > 0)
+        while (a2 < a1) a2 += 360;
+    else
+        while (a2 > a1) a2 -= 360;
+    /* a runaway sweep would otherwise fill the operand stack a segment
+       at a time; sixteen revolutions is beyond any drawing's use */
+    if (fabs(a2 - a1) > 5760)
+        a2 = a1 + dir * 5760;
+
+    cur = a1;
+    b = dir > 0 ? (floor(a1 / 90) + 1) * 90 : (ceil(a1 / 90) - 1) * 90;
+    while (n < 65 && (dir > 0 ? b < a2 : b > a2))
+    {
+        segs[n][0] = cur; segs[n][1] = b; n++;
+        cur = b;
+        b += dir * 90;
+    }
+    if (fabs(a2 - cur) > 1e-9)
+    {
+        segs[n][0] = cur; segs[n][1] = a2; n++;
+    }
+
+    for (i = n; i-- > 0; )
+        _arcbezseg(ctx, cx, cy, rr, segs[i][0], segs[i][1]);
+    sx = (real)(cx + rr * cos(a1 * RAD_PER_DEG));
+    sy = (real)(cy + rr * sin(a1 * RAD_PER_DEG));
+    xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(sx));
+    xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons(sy));
+
+    for (i = 0; i < n; i++)
+        xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons_opcode(_curveto_opcode));
+    xpost_stack_push(ctx->lo, ctx->es, _arc_start_proc);
     return 0;
 }
 
@@ -594,34 +654,7 @@ int _arc(Xpost_Context *ctx,
          Xpost_Object x, Xpost_Object y, Xpost_Object r,
          Xpost_Object angle1, Xpost_Object angle2)
 {
-    double a1 = angle1.real_.val;
-    double a2 = angle2.real_.val;
-    while (a2 < a1)
-    {
-        double t;
-        t = a2 + 360;
-        a2 = t;
-    }
-    if ((a2 - a1) > 90)
-    {
-        _arc(ctx, x, y, r, xpost_real_cons(a1), xpost_real_cons((real)(a2 - ((a2 - a1)/2.0))));
-        _arc(ctx, x, y, r, xpost_real_cons((real)(a1 + ((a2 - a1)/2.0))), xpost_real_cons(a2));
-    }
-    else
-    {
-        //Xpost_Object path = _cpath(ctx);
-        //int pathlen = xpost_dict_length_memory(xpost_context_select_memory(ctx, path), path);
-        _arcbez(ctx, x, y, r, xpost_real_cons(a1), xpost_real_cons(a2));
-        xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons_opcode(_curveto_opcode));
-        xpost_stack_push(ctx->lo, ctx->es, _arc_start_proc);
-        /*
-        if (pathlen)
-            xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons_opcode(_lineto_opcode));
-        else
-            xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons_opcode(_moveto_opcode));
-            */
-    }
-    return 0;
+    return _arc_append(ctx, x, y, r, angle1, angle2, 1);
 }
 
 static
@@ -629,34 +662,7 @@ int _arcn(Xpost_Context *ctx,
           Xpost_Object x, Xpost_Object y, Xpost_Object r,
           Xpost_Object angle1, Xpost_Object angle2)
 {
-    real a1 = angle1.real_.val;
-    real a2 = angle2.real_.val;
-    while (a2 > a1)
-    {
-        double t;
-        t = a2 - 360;
-        a2 = t;
-    }
-    if ((a1 - a2) > 90)
-    {
-        _arcn(ctx, x, y, r, xpost_real_cons(a1), xpost_real_cons(a2 + (real)((a1 - a2)/2.0)));
-        _arcn(ctx, x, y, r, xpost_real_cons(a1 - (real)((a1 - a2)/2.0)), xpost_real_cons(a2));
-    }
-    else
-    {
-        //Xpost_Object path = _cpath(ctx);
-        //int pathlen = xpost_dict_length_memory(xpost_context_select_memory(ctx, path), path);
-        _arcbez(ctx, x, y, r, xpost_real_cons(a1), xpost_real_cons(a2));
-        xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons_opcode(_curveto_opcode));
-        xpost_stack_push(ctx->lo, ctx->es, _arc_start_proc);
-        /*
-        if (pathlen)
-            xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons_opcode(_lineto_opcode));
-        else
-            xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons_opcode(_moveto_opcode));
-            */
-    }
-    return 0;
+    return _arc_append(ctx, x, y, r, angle1, angle2, -1);
 }
 
 #define NUM(x) (xpost_object_get_type(x)==realtype?x.real_.val:(real)x.int_.val)

--- a/src/lib/xpost_op_path.c
+++ b/src/lib/xpost_op_path.c
@@ -98,6 +98,8 @@ static unsigned int _curveto_cont1_opcode;
 static unsigned int _curveto_cont2_opcode;
 static unsigned int _curveto_cont3_opcode;
 static unsigned int _rcurveto_cont_opcode;
+static unsigned int _arct_cont_opcode;
+static unsigned int _arcto_cont_opcode;
 
 /*matrices*/
 static Xpost_Object _mat;
@@ -601,14 +603,9 @@ void _arcbezseg(Xpost_Context *ctx,
    are pushed in reverse. */
 static
 int _arc_append(Xpost_Context *ctx,
-                Xpost_Object x, Xpost_Object y, Xpost_Object r,
-                Xpost_Object angle1, Xpost_Object angle2, int dir)
+                double cx, double cy, double rr,
+                double a1, double a2, int dir)
 {
-    double cx = x.real_.val;
-    double cy = y.real_.val;
-    double rr = r.real_.val;
-    double a1 = angle1.real_.val;
-    double a2 = angle2.real_.val;
     double segs[66][2];
     double cur, b;
     int n = 0, i;
@@ -654,7 +651,8 @@ int _arc(Xpost_Context *ctx,
          Xpost_Object x, Xpost_Object y, Xpost_Object r,
          Xpost_Object angle1, Xpost_Object angle2)
 {
-    return _arc_append(ctx, x, y, r, angle1, angle2, 1);
+    return _arc_append(ctx, x.real_.val, y.real_.val, r.real_.val,
+                       angle1.real_.val, angle2.real_.val, 1);
 }
 
 static
@@ -662,7 +660,140 @@ int _arcn(Xpost_Context *ctx,
           Xpost_Object x, Xpost_Object y, Xpost_Object r,
           Xpost_Object angle1, Xpost_Object angle2)
 {
-    return _arc_append(ctx, x, y, r, angle1, angle2, -1);
+    return _arc_append(ctx, x.real_.val, y.real_.val, r.real_.val,
+                       angle1.real_.val, angle2.real_.val, -1);
+}
+
+/* Shared arct/arcto continuation, entered with the five operands and
+   the current point, delivered in user space by the scheduled
+   currentpoint. The arc has radius r and is tangent to the ray from
+   the current point toward (x1,y1) and to the ray from (x1,y1) toward
+   (x2,y2): its centre sits on the corner's angle bisector at
+   r/sin(half-angle) and the tangent points at r*cos/sin(half-angle)
+   out along each ray, with the sweep direction given by the sign of
+   the rays' cross product. The straight segment from the current
+   point to the first tangent point falls out of _arc_append, whose
+   start proc linetos on a non-empty path. When report is set (arcto)
+   the four tangent coordinates are pushed before the arc's operands:
+   the scheduled arc consumes its own from above, leaving them as the
+   operator's results. */
+static
+int _arct_common(Xpost_Context *ctx,
+                 double x1, double y1, double x2, double y2, double r,
+                 double x0, double y0, int report)
+{
+    double dx0, dy0, dx2, dy2, sql0, sql2, cross;
+    double ux0, uy0, ux2, uy2, sinhalf, coshalf, tanlen, bx, by, blen;
+    double cx, cy, t1x, t1y, t2x, t2y, a1, a2;
+
+    if (r < 0)
+        return rangecheck;
+    dx0 = x0 - x1; dy0 = y0 - y1;
+    dx2 = x2 - x1; dy2 = y2 - y1;
+    sql0 = dx0 * dx0 + dy0 * dy0;
+    sql2 = dx2 * dx2 + dy2 * dy2;
+    if (sql0 == 0.0 || sql2 == 0.0)
+        return undefinedresult; /* a tangent ray has no direction */
+    cross = dx0 * dy2 - dy0 * dx2;
+    if (cross == 0.0 || r == 0.0)
+    {
+        /* collinear rays or a radius of zero: both tangent points
+           collapse onto the corner, the arc is empty and only the
+           straight segment survives */
+        if (report)
+        {
+            xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons((real)x1));
+            xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons((real)y1));
+            xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons((real)x1));
+            xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons((real)y1));
+        }
+        return _lineto(ctx, xpost_real_cons((real)x1), xpost_real_cons((real)y1));
+    }
+    ux0 = dx0 / sqrt(sql0); uy0 = dy0 / sqrt(sql0);
+    ux2 = dx2 / sqrt(sql2); uy2 = dy2 / sqrt(sql2);
+    /* half-angle identities on the rays' dot product; the clamps keep
+       rounding from pushing the square roots' arguments negative */
+    {
+        double cosq = ux0 * ux2 + uy0 * uy2;
+        if (cosq > 1.0) cosq = 1.0;
+        if (cosq < -1.0) cosq = -1.0;
+        sinhalf = sqrt((1.0 - cosq) / 2.0); /* nonzero: not collinear */
+        coshalf = sqrt((1.0 + cosq) / 2.0);
+    }
+    tanlen = r * coshalf / sinhalf;
+    /* the unnormalised bisector u0+u2 has length 2*cos(half-angle) */
+    bx = ux0 + ux2; by = uy0 + uy2;
+    blen = sqrt(bx * bx + by * by);
+    cx = x1 + bx / blen * (r / sinhalf);
+    cy = y1 + by / blen * (r / sinhalf);
+    t1x = x1 + ux0 * tanlen; t1y = y1 + uy0 * tanlen;
+    t2x = x1 + ux2 * tanlen; t2y = y1 + uy2 * tanlen;
+    a1 = atan2(t1y - cy, t1x - cx) / RAD_PER_DEG;
+    a2 = atan2(t2y - cy, t2x - cx) / RAD_PER_DEG;
+    if (report)
+    {
+        xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons((real)t1x));
+        xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons((real)t1y));
+        xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons((real)t2x));
+        xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons((real)t2y));
+    }
+    return _arc_append(ctx, cx, cy, r, a1, a2, cross < 0.0 ? 1 : -1);
+}
+
+static
+int _arct(Xpost_Context *ctx,
+          Xpost_Object x1, Xpost_Object y1,
+          Xpost_Object x2, Xpost_Object y2,
+          Xpost_Object r)
+{
+    xpost_stack_push(ctx->lo, ctx->os, x1);
+    xpost_stack_push(ctx->lo, ctx->os, y1);
+    xpost_stack_push(ctx->lo, ctx->os, x2);
+    xpost_stack_push(ctx->lo, ctx->os, y2);
+    xpost_stack_push(ctx->lo, ctx->os, r);
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons_opcode(_arct_cont_opcode));
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons_opcode(_currentpoint_opcode));
+    return 0;
+}
+
+static
+int _arct_cont(Xpost_Context *ctx,
+               Xpost_Object x1, Xpost_Object y1,
+               Xpost_Object x2, Xpost_Object y2,
+               Xpost_Object r,
+               Xpost_Object x0, Xpost_Object y0)
+{
+    return _arct_common(ctx, x1.real_.val, y1.real_.val,
+                        x2.real_.val, y2.real_.val, r.real_.val,
+                        x0.real_.val, y0.real_.val, 0);
+}
+
+static
+int _arcto(Xpost_Context *ctx,
+           Xpost_Object x1, Xpost_Object y1,
+           Xpost_Object x2, Xpost_Object y2,
+           Xpost_Object r)
+{
+    xpost_stack_push(ctx->lo, ctx->os, x1);
+    xpost_stack_push(ctx->lo, ctx->os, y1);
+    xpost_stack_push(ctx->lo, ctx->os, x2);
+    xpost_stack_push(ctx->lo, ctx->os, y2);
+    xpost_stack_push(ctx->lo, ctx->os, r);
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons_opcode(_arcto_cont_opcode));
+    xpost_stack_push(ctx->lo, ctx->es, xpost_operator_cons_opcode(_currentpoint_opcode));
+    return 0;
+}
+
+static
+int _arcto_cont(Xpost_Context *ctx,
+                Xpost_Object x1, Xpost_Object y1,
+                Xpost_Object x2, Xpost_Object y2,
+                Xpost_Object r,
+                Xpost_Object x0, Xpost_Object y0)
+{
+    return _arct_common(ctx, x1.real_.val, y1.real_.val,
+                        x2.real_.val, y2.real_.val, r.real_.val,
+                        x0.real_.val, y0.real_.val, 1);
 }
 
 #define NUM(x) (xpost_object_get_type(x)==realtype?x.real_.val:(real)x.int_.val)
@@ -949,6 +1080,20 @@ int xpost_oper_init_path_ops(Xpost_Context *ctx,
     op = xpost_operator_cons(ctx, "arcn", (Xpost_Op_Func)_arcn, 0, 5,
                              floattype, floattype, floattype, floattype, floattype);
     INSTALL;
+
+    op = xpost_operator_cons(ctx, "arct", (Xpost_Op_Func)_arct, 0, 5,
+                             floattype, floattype, floattype, floattype, floattype);
+    INSTALL;
+    op = xpost_operator_cons(ctx, "arct_cont", (Xpost_Op_Func)_arct_cont, 0, 7,
+                             floattype, floattype, floattype, floattype, floattype, floattype, floattype);
+    _arct_cont_opcode = op.mark_.padw;
+
+    op = xpost_operator_cons(ctx, "arcto", (Xpost_Op_Func)_arcto, 4, 5,
+                             floattype, floattype, floattype, floattype, floattype);
+    INSTALL;
+    op = xpost_operator_cons(ctx, "arcto_cont", (Xpost_Op_Func)_arcto_cont, 4, 7,
+                             floattype, floattype, floattype, floattype, floattype, floattype, floattype);
+    _arcto_cont_opcode = op.mark_.padw;
 
     op = xpost_operator_cons(ctx, "flattenpath", (Xpost_Op_Func)_flattenpath, 0, 0);
     INSTALL;

--- a/src/lib/xpost_op_path.c
+++ b/src/lib/xpost_op_path.c
@@ -752,6 +752,10 @@ int _flattenpath (Xpost_Context *ctx)
     xpost_stack_push(ctx->lo, ctx->hold, gd);
     gstate = xpost_dict_get(ctx, gd, namecurrgstate);
     flat = xpost_dict_get(ctx, gstate, xpost_name_cons(ctx, "flat"));
+    /* the flatness value bounds the error in device pixels; subdivide
+       well inside it so a curve's polygonization classifies the same
+       boundary pixels as a renderer that meets the bound exactly */
+    flat = xpost_real_cons((real)(NUM(flat) * 0.25));
 
     path = _cpath(ctx);
     pathlen = xpost_dict_length_memory(xpost_context_select_memory(ctx, path), path);

--- a/src/lib/xpost_op_save.c
+++ b/src/lib/xpost_op_save.c
@@ -58,6 +58,15 @@
 static
 int Zsave(Xpost_Context *ctx)
 {
+    unsigned int vs;
+
+    /* each object's mark records the save level (as level+1) in an 8-bit
+       field, so the save stack cannot exceed 255 levels without aliasing
+       another level's bookkeeping */
+    if (xpost_memory_table_get_addr(ctx->lo,
+            XPOST_MEMORY_TABLE_SPECIAL_SAVE_STACK, &vs)
+        && xpost_stack_count(ctx->lo, vs) >= 255)
+        return limitcheck;
     if (!xpost_stack_push(ctx->lo, ctx->os, xpost_save_create_snapshot_object(ctx->lo)))
         return stackoverflow;
     return 0;

--- a/src/lib/xpost_op_save.c
+++ b/src/lib/xpost_op_save.c
@@ -63,11 +63,17 @@ int Zsave(Xpost_Context *ctx)
     /* each object's mark records the save level (as level+1) in an 8-bit
        field, so the save stack cannot exceed 255 levels without aliasing
        another level's bookkeeping */
+    Xpost_Object v;
+
     if (xpost_memory_table_get_addr(ctx->lo,
             XPOST_MEMORY_TABLE_SPECIAL_SAVE_STACK, &vs)
         && xpost_stack_count(ctx->lo, vs) >= 255)
         return limitcheck;
-    if (!xpost_stack_push(ctx->lo, ctx->os, xpost_save_create_snapshot_object(ctx->lo)))
+    v = xpost_save_create_snapshot_object(ctx->lo);
+    /* remember the packing mode at this level so restore reverts it */
+    if (v.save_.lev < sizeof ctx->packing_hist)
+        ctx->packing_hist[v.save_.lev] = (unsigned char)ctx->packing;
+    if (!xpost_stack_push(ctx->lo, ctx->os, v))
         return stackoverflow;
     return 0;
 }
@@ -95,6 +101,9 @@ int Vrestore(Xpost_Context *ctx,
         xpost_save_restore_snapshot(ctx->lo);
         z--;
     }
+    /* the packing mode is save/restore-subject: revert it to this level */
+    if (V.save_.lev < sizeof ctx->packing_hist)
+        ctx->packing = ctx->packing_hist[V.save_.lev];
     return 0;
 }
 

--- a/src/lib/xpost_op_save.c
+++ b/src/lib/xpost_op_save.c
@@ -109,7 +109,9 @@ int Zcurrentglobal(Xpost_Context *ctx)
 }
 
 /* any  gcheck  bool
-   check whether value is a legal element of a global composite object */
+   check whether value is a legal element of a global composite
+   object: simple objects always are; composite objects are when
+   their value lives in global VM */
 static
 int Agcheck(Xpost_Context *ctx,
             Xpost_Object A)
@@ -118,11 +120,11 @@ int Agcheck(Xpost_Context *ctx,
     switch(xpost_object_get_type(A))
     {
         default:
-            r = xpost_bool_cons(0); break;
+            r = xpost_bool_cons(1); break;
         case stringtype:
-        case nametype:
         case dicttype:
         case arraytype:
+        case filetype:
             r = xpost_bool_cons((A.tag&XPOST_OBJECT_TAG_DATA_FLAG_BANK)!=0);
     }
     xpost_stack_push(ctx->lo, ctx->os, r);

--- a/src/lib/xpost_op_save.c
+++ b/src/lib/xpost_op_save.c
@@ -60,7 +60,6 @@ int Zsave(Xpost_Context *ctx)
 {
     if (!xpost_stack_push(ctx->lo, ctx->os, xpost_save_create_snapshot_object(ctx->lo)))
         return stackoverflow;
-    printf("save\n");
     return 0;
 }
 
@@ -87,7 +86,6 @@ int Vrestore(Xpost_Context *ctx,
         xpost_save_restore_snapshot(ctx->lo);
         z--;
     }
-    printf("restore\n");
     return 0;
 }
 

--- a/src/lib/xpost_op_stack.c
+++ b/src/lib/xpost_op_stack.c
@@ -142,6 +142,8 @@ int IIroll(Xpost_Context *ctx,
     if (j == 0) return 0;
 
     t = malloc((n - j) * sizeof(Xpost_Object));
+    if (!t)
+        return VMerror;
     for (i = 0; i < n-j; i++)
     {
         r = xpost_stack_topdown_fetch(ctx->lo, ctx->os, n - 1 - i);

--- a/src/lib/xpost_op_stack.c
+++ b/src/lib/xpost_op_stack.c
@@ -225,18 +225,18 @@ int xpost_op_cleartomark(Xpost_Context *ctx)
    count elements down to mark */
 int xpost_op_counttomark(Xpost_Context *ctx)
 {
-    unsigned i;
-    unsigned z;
-    z = xpost_stack_count(ctx->lo, ctx->os);
-    for (i = 0; i < z; i++)
-    {
-        if (xpost_stack_topdown_fetch(ctx->lo, ctx->os, i).tag == marktype)
-        {
-            xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons(i));
-            return 0;
-        }
-    }
-    return unmatchedmark;
+    /* One top-down pass to the mark. The former loop fetched each operand with
+       xpost_stack_topdown_fetch per index, and each of those re-walks the
+       segment chain, so counttomark was O(depth^2). counttomark also underlies
+       the [ ] and << >> constructors (via xpost_op_array_to_mark /
+       xpost_op_dict_to_mark), so a large array or dictionary literal inherited
+       that quadratic cost. */
+    int i = xpost_stack_topdown_find_type(ctx->lo, ctx->os, marktype, NULL);
+    if (i < 0)
+        return unmatchedmark;
+    if (!xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons(i)))
+        return stackoverflow;
+    return 0;
 }
 
 int xpost_oper_init_stack_ops(Xpost_Context *ctx,

--- a/src/lib/xpost_op_string.c
+++ b/src/lib/xpost_op_string.c
@@ -217,7 +217,12 @@ int Ssearch(Xpost_Context *ctx,
     Xpost_Object interval;
 
     if (seek.comp_.sz > str.comp_.sz)
-        return rangecheck;
+    {
+        /* seek cannot match: report not-found, per PLRM */
+        xpost_stack_push(ctx->lo, ctx->os, str);
+        xpost_stack_push(ctx->lo, ctx->os, xpost_bool_cons(0));
+        return 0;
+    }
     s = xpost_string_get_pointer(ctx, str);
     k = xpost_string_get_pointer(ctx, seek);
     for (i = 0; i <= (str.comp_.sz - seek.comp_.sz); i++)

--- a/src/lib/xpost_op_string.c
+++ b/src/lib/xpost_op_string.c
@@ -55,6 +55,12 @@ int Istring(Xpost_Context *ctx,
             Xpost_Object I)
 {
     Xpost_Object str;
+
+    if (I.int_.val < 0)
+        return rangecheck;
+    if (I.int_.val > 65535) /* sz field is 16 bits; PLRM minimum limit */
+        return limitcheck;
+
     str = xpost_string_cons(ctx, I.int_.val, NULL);
     if (xpost_object_get_type(str) == nulltype)
         return VMerror;
@@ -218,7 +224,7 @@ int Ssearch(Xpost_Context *ctx,
 
     if (seek.comp_.sz > str.comp_.sz)
     {
-        /* seek cannot match: report not-found, per PLRM */
+        /* needle cannot match: report not-found, per PLRM */
         xpost_stack_push(ctx->lo, ctx->os, str);
         xpost_stack_push(ctx->lo, ctx->os, xpost_bool_cons(0));
         return 0;

--- a/src/lib/xpost_op_token.c
+++ b/src/lib/xpost_op_token.c
@@ -607,7 +607,8 @@ int Snext(Xpost_Context *ctx,
 {
     int ret;
     if (S->comp_.sz == 0) return EOF;
-    ret = xpost_string_get_pointer(ctx, *S)[0];
+    /* the byte must not sign-extend into EOF */
+    ret = (unsigned char)xpost_string_get_pointer(ctx, *S)[0];
     ++S->comp_.off;
     --S->comp_.sz;
     return ret;

--- a/src/lib/xpost_op_token.c
+++ b/src/lib/xpost_op_token.c
@@ -517,7 +517,16 @@ int puff(Xpost_Context *ctx,
         if (s - buf >= nbuf) return 0;
         *s++ = c;
     }
-    if (!isspace(c) && c != EOF) back(ctx, c, src);
+    if (c == '\r')
+    {
+        /* an end-of-line marker is one white-space character however
+           written (PLRM 3.8): a CR delimiter claims its LF */
+        int c2 = next(ctx, src);
+        if (c2 != '\n' && c2 != EOF)
+            back(ctx, c2, src);
+    }
+    else if (!isspace(c) && c != EOF)
+        back(ctx, c, src);
     return s - buf;
 }
 

--- a/src/lib/xpost_op_token.c
+++ b/src/lib/xpost_op_token.c
@@ -274,10 +274,33 @@ int grok(Xpost_Context *ctx,
                     {
                         case '(': ++defer; break;
                         case ')': --defer; break;
+                        case '\r':
+                        {
+                            /* an end-of-line marker inside a string is
+                               one newline character, whichever of the
+                               three conventions wrote it */
+                            int c2 = next(ctx, src);
+
+                            if (c2 != '\n' && c2 != EOF)
+                                back(ctx, c2, src);
+                            c = '\n';
+                            break;
+                        }
                         case '\\':
                             switch(c = next(ctx, src))
                             {
                                 case '\n': continue;
+                                case '\r':
+                                {
+                                    /* an escaped end-of-line joins the
+                                       lines: nothing is inserted, for
+                                       CR alone or CR LF */
+                                    int c2 = next(ctx, src);
+
+                                    if (c2 != '\n' && c2 != EOF)
+                                        back(ctx, c2, src);
+                                    continue;
+                                }
                                 case 'a': c = '\a'; break;
                                 case 'b': c = '\b'; break;
                                 case 'f': c = '\f'; break;

--- a/src/lib/xpost_op_token.c
+++ b/src/lib/xpost_op_token.c
@@ -229,22 +229,36 @@ int grok(Xpost_Context *ctx,
 
     else if (fsm_check(s, ns, fsm_rad, accept_rad))
     {
-        long base, num;
-        base = strtol(s, &s, 10);
+        unsigned long base, num;
+        base = strtoul(s, &s, 10);
         if ((base > 36) || (base < 2))
         {
             XPOST_LOG_ERR("bad radix");
             return limitcheck;
         }
         errno = 0;
-        num = strtol(s + 1, NULL, base);
-        if ((num == LONG_MAX || num == LONG_MIN) && errno == ERANGE)
+        /* PLRM 3.2: a radix number is unsigned. Read it unsigned so the full
+           integer width parses on every platform: where long is no wider than
+           int (LLP64, e.g. Windows), a signed read would overflow on any value
+           past INT_MAX -- 16#FFFFFFFF among them -- and spuriously limitcheck. */
+        num = strtoul(s + 1, NULL, base);
+        if (errno == ERANGE)
         {
             XPOST_LOG_ERR("radixnumber out of range");
             return limitcheck;
         }
-        //return xpost_int_cons(num);
-        *retval = xpost_int_cons(num);
+        /* it keeps the same twos-complement representation, so it must fit the
+           integer type's bit width; one that exceeds it is a limitcheck (not
+           narrowed, and not promoted to a real the way an over-range decimal
+           integer is). Where long is wider than int the value parsed above but
+           may still be too wide; ERANGE has already caught it where it did not. */
+        if (sizeof(integer) < sizeof(long)
+                && num > (((unsigned long)1 << (8 * sizeof(integer))) - 1))
+        {
+            XPOST_LOG_ERR("radixnumber exceeds integer width");
+            return limitcheck;
+        }
+        *retval = xpost_int_cons((integer)num);
         return 0;
     }
 

--- a/src/lib/xpost_op_token.c
+++ b/src/lib/xpost_op_token.c
@@ -309,17 +309,28 @@ int grok(Xpost_Context *ctx,
                                 case 't': c = '\t'; break;
                                 case 'v': c = '\v'; break;
                                 default:
-                                    if (isdigit(c))
+                                    if (c >= '0' && c <= '7')
                                     {
-                                        int t = 0, n = 0;
-                                        do {
-                                            t *= 8;
-                                            t += c - '0';
-                                            ++n;
-                                            c = next(ctx, src);
-                                        } while (isdigit(c) && n < 3);
-                                        if (!isdigit(c)) back(ctx, c, src);
-                                        c = t;
+                                        /* up to three octal digits, and
+                                           only octal ones: 8 and 9 end the
+                                           escape, and the character after
+                                           the third digit is not part of it */
+                                        int t = c - '0', n = 1;
+                                        while (n < 3)
+                                        {
+                                            int d = next(ctx, src);
+                                            if (d >= '0' && d <= '7')
+                                            {
+                                                t = t * 8 + (d - '0');
+                                                ++n;
+                                            }
+                                            else
+                                            {
+                                                if (d != EOF) back(ctx, d, src);
+                                                break;
+                                            }
+                                        }
+                                        c = t & 0xff;
                                     }
                             }
                     }

--- a/src/lib/xpost_op_token.c
+++ b/src/lib/xpost_op_token.c
@@ -466,7 +466,15 @@ int grok(Xpost_Context *ctx,
                 {
                     ret = xpost_op_array_to_mark(ctx);  // ie. the /] operator
                     if (ret == 0)
-                        *retval = xpost_object_cvx(xpost_stack_pop(ctx->lo, ctx->os));
+                    {
+                        Xpost_Object proc = xpost_stack_pop(ctx->lo, ctx->os);
+                        /* in packing mode a procedure is built read-only, which
+                           is how xpost represents a packed array */
+                        if (ctx->packing)
+                            proc = xpost_object_set_access(ctx, proc,
+                                    XPOST_OBJECT_TAG_ACCESS_READ_ONLY);
+                        *retval = xpost_object_cvx(proc);
+                    }
                 }
                 --depth;
                 return ret;

--- a/src/lib/xpost_op_token.c
+++ b/src/lib/xpost_op_token.c
@@ -424,6 +424,14 @@ int grok(Xpost_Context *ctx,
                     //printf("grok: x?%d", xpost_object_is_exe(t));
                     if (ret)
                         return ret;
+                    /* the source ended inside the procedure: the
+                       scanner answers a null there and nowhere else,
+                       a literal null in the text being a name */
+                    if (xpost_object_get_type(t) == nulltype)
+                    {
+                        XPOST_LOG_ERR("end of input inside a procedure");
+                        return syntaxerror;
+                    }
                     if ((xpost_object_get_type(t) == nametype) &&
                         (xpost_dict_compare_objects(ctx, t, tail) == 0))
                         break;

--- a/src/lib/xpost_op_token.c
+++ b/src/lib/xpost_op_token.c
@@ -215,13 +215,14 @@ int grok(Xpost_Context *ctx,
     if (fsm_check(s, ns, fsm_dec, accept_dec))
     {
         long num;
+        errno = 0;
         num = strtol(s, NULL, 10);
-        if ((num == LONG_MAX || num == LONG_MIN) && errno==ERANGE)
+        if (errno == ERANGE || (long)(integer)num != num)
         {
-            XPOST_LOG_ERR("integer out of range");
-            return limitcheck;
+            /* beyond the integer range: PLRM 3.3.2 makes it a real */
+            *retval = xpost_real_cons((real)strtod(s, NULL));
+            return 0;
         }
-        //return xpost_int_cons(num);
         *retval = xpost_int_cons(num);
         return 0;
     }

--- a/src/lib/xpost_op_token.c
+++ b/src/lib/xpost_op_token.c
@@ -424,36 +424,52 @@ int grok(Xpost_Context *ctx,
 
             case '{':
             { // This is the one part that makes it a recursive-descent parser
+                /* each level is a toke() frame carrying a 64 KB token buffer;
+                   cap the nesting well within the C stack and raise
+                   limitcheck beyond it. The counter unwinds on the single
+                   exit below, so scans stay balanced. */
+                enum { PROC_NEST_MAX = 100 };
+                static int depth = 0;
                 int ret;
                 Xpost_Object tail;
+
+                if (++depth > PROC_NEST_MAX)
+                {
+                    --depth;
+                    XPOST_LOG_ERR("procedure nesting too deep");
+                    return limitcheck;
+                }
                 tail = xpost_name_cons(ctx, "}");
                 xpost_stack_push(ctx->lo, ctx->os, mark);
+                ret = 0;
                 while (1)
                 {
                     Xpost_Object t;
                     ret = toke(ctx, src, next, back, &t);
-                    //printf("grok: x?%d", xpost_object_is_exe(t));
                     if (ret)
-                        return ret;
+                        break;
                     /* the source ended inside the procedure: the
                        scanner answers a null there and nowhere else,
                        a literal null in the text being a name */
                     if (xpost_object_get_type(t) == nulltype)
                     {
                         XPOST_LOG_ERR("end of input inside a procedure");
-                        return syntaxerror;
+                        ret = syntaxerror;
+                        break;
                     }
                     if ((xpost_object_get_type(t) == nametype) &&
                         (xpost_dict_compare_objects(ctx, t, tail) == 0))
                         break;
                     xpost_stack_push(ctx->lo, ctx->os, t);
                 }
-                ret = xpost_op_array_to_mark(ctx);  // ie. the /] operator
-                if (ret)
-                    return ret;
-                //return xpost_object_cvx(xpost_stack_pop(ctx->lo, ctx->os));
-                *retval = xpost_object_cvx(xpost_stack_pop(ctx->lo, ctx->os));
-                return 0;
+                if (ret == 0)
+                {
+                    ret = xpost_op_array_to_mark(ctx);  // ie. the /] operator
+                    if (ret == 0)
+                        *retval = xpost_object_cvx(xpost_stack_pop(ctx->lo, ctx->os));
+                }
+                --depth;
+                return ret;
             }
 
             case '/':

--- a/src/lib/xpost_op_type.c
+++ b/src/lib/xpost_op_type.c
@@ -174,8 +174,22 @@ int Ncvi(Xpost_Context *ctx,
     return 0;
 }
 
-/* helper function: interpret the whole string as a PostScript numeral
-   (decimal or radix form); returns 0 on success or an error code */
+/* a numeral token's end: white space, a delimiter, or the string's */
+static
+int _num_token_end(char c)
+{
+    return c == '\0' || c == ' ' || c == '\t' || c == '\n'
+        || c == '\r' || c == '\f'
+        || c == '(' || c == ')' || c == '<' || c == '>'
+        || c == '[' || c == ']' || c == '{' || c == '}'
+        || c == '/' || c == '%';
+}
+
+/* helper function: read a PostScript numeral (decimal or radix form)
+   from the string with the scanner's token semantics -- leading
+   white space skipped, the token must be a complete numeral, and
+   whatever follows its end is ignored; returns 0 on success or an
+   error code */
 static
 int _string_to_number(const char *t,
                       double *out)
@@ -184,6 +198,10 @@ int _string_to_number(const char *t,
     long base;
     double num;
 
+    while (*t == ' ' || *t == '\t' || *t == '\n'
+        || *t == '\r' || *t == '\f')
+        t++;
+
     /* radix numeral, e.g. 16#ff */
     errno = 0;
     base = strtol(t, &end, 10);
@@ -191,11 +209,11 @@ int _string_to_number(const char *t,
     {
         long v;
         const char *p = end + 1;
-        if (*p == '\0')
+        if (_num_token_end(*p))
             return typecheck;
         errno = 0;
         v = strtol(p, &end, (int)base);
-        if (*end != '\0')
+        if (!_num_token_end(*end))
             return typecheck;
         if (errno == ERANGE)
             return limitcheck;
@@ -205,7 +223,7 @@ int _string_to_number(const char *t,
 
     errno = 0;
     num = strtod(t, &end);
-    if (end == t || *end != '\0')
+    if (end == t || !_num_token_end(*end))
         return typecheck;
     if (errno == ERANGE)
         return limitcheck;

--- a/src/lib/xpost_op_type.c
+++ b/src/lib/xpost_op_type.c
@@ -467,19 +467,25 @@ int AScvs (Xpost_Context *ctx,
         break;
         case integertype:
         {
-            //n = conv_rad(any.int_.val, 10, xpost_string_get_pointer(ctx, str), str.comp_.sz);
+            /* write digits from the integer itself: a detour through
+               real drops bits past the float mantissa, and negating
+               the most negative integer does not exist */
             char *s = xpost_string_get_pointer(ctx, str);
-            int sz = str.comp_.sz;
-            n = 0;
-            if (any.int_.val < 0)
-            {
-                s[n++] = '-';
-                any.int_.val = abs(any.int_.val);
-                --sz;
-            }
-            n += conv_integ((real)any.int_.val, s + n, sz);
-            if (n == -1)
+            char t[24];
+            unsigned int u;
+            int neg = any.int_.val < 0;
+            int len = 0;
+
+            u = neg ? -(unsigned int)any.int_.val : (unsigned int)any.int_.val;
+            do { t[len++] = (char)(0x30 + u % 10); u /= 10; } while (u);
+            n = neg + len;
+            if (n > (int)str.comp_.sz)
                 return rangecheck;
+            {
+                int i = 0;
+                if (neg) s[i++] = 0x2d;
+                while (len) s[i++] = t[--len];
+            }
             if (n < str.comp_.sz) str.comp_.sz = n;
             break;
         }

--- a/src/lib/xpost_op_type.c
+++ b/src/lib/xpost_op_type.c
@@ -174,35 +174,63 @@ int Ncvi(Xpost_Context *ctx,
     return 0;
 }
 
+/* helper function: interpret the whole string as a PostScript numeral
+   (decimal or radix form); returns 0 on success or an error code */
+static
+int _string_to_number(const char *t,
+                      double *out)
+{
+    char *end;
+    long base;
+    double num;
+
+    /* radix numeral, e.g. 16#ff */
+    errno = 0;
+    base = strtol(t, &end, 10);
+    if (end != t && *end == '#' && base >= 2 && base <= 36)
+    {
+        long v;
+        const char *p = end + 1;
+        if (*p == '\0')
+            return typecheck;
+        errno = 0;
+        v = strtol(p, &end, (int)base);
+        if (*end != '\0')
+            return typecheck;
+        if (errno == ERANGE)
+            return limitcheck;
+        *out = (double)v;
+        return 0;
+    }
+
+    errno = 0;
+    num = strtod(t, &end);
+    if (end == t || *end != '\0')
+        return typecheck;
+    if (errno == ERANGE)
+        return limitcheck;
+    *out = num;
+    return 0;
+}
+
 /* string  cvi  int
-   convert initial portion of string to integer */
+   convert string numeral to integer */
 static
 int Scvi(Xpost_Context *ctx,
          Xpost_Object s)
 {
     double dbl;
-    long num;
+    int ret;
     char *t = xpost_string_allocate_cstring(ctx, s);
 
-    dbl = strtod(t, NULL);
-    if ((dbl == HUGE_VAL || dbl -HUGE_VAL) && errno==ERANGE){
-        free(t);
-        return limitcheck;
-    }
-    if (dbl >= (double)LONG_MAX || dbl <= (double)LONG_MIN){
-        free(t);
-        return limitcheck;
-    }
-    num = (long)dbl;
-
-    /*
-      num = strtol(t, NULL, 10);
-      if ((num == LONG_MAX || num == LONG_MIN) && errno==ERANGE)
-      return limitcheck;
-    */
-
-    xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons(num));
+    ret = _string_to_number(t, &dbl);
     free(t);
+    if (ret)
+        return ret;
+    if (dbl >= LONG_MAX || dbl <= LONG_MIN)
+        return limitcheck;
+
+    xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons((long)dbl));
     return 0;
 }
 
@@ -251,20 +279,21 @@ int Ncvr(Xpost_Context *ctx,
 }
 
 /* string  cvr  real
-   convert initial portion of string to real */
+   convert string numeral to real */
 static
 int Scvr(Xpost_Context *ctx,
          Xpost_Object str)
 {
     double num;
+    int ret;
     char *s = xpost_string_allocate_cstring(ctx, str);
-    num = strtod(s, NULL);
-    if ((num == HUGE_VAL || num -HUGE_VAL) && errno == ERANGE){
-        free(s);
-        return limitcheck;
-    }
-    xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons((real)num));
+
+    ret = _string_to_number(s, &num);
     free(s);
+    if (ret)
+        return ret;
+
+    xpost_stack_push(ctx->lo, ctx->os, xpost_real_cons((real)num));
     return 0;
 }
 

--- a/src/lib/xpost_op_type.c
+++ b/src/lib/xpost_op_type.c
@@ -462,8 +462,6 @@ int AScvs (Xpost_Context *ctx,
     char nostringval[] = "--nostringval--";
     char strue[] = "true";
     char sfalse[] = "false";
-    char smark[] = "-mark-";
-    char ssave[] = "-save-";
     int n;
     int ret;
 
@@ -474,20 +472,6 @@ int AScvs (Xpost_Context *ctx,
                 return rangecheck;
             memcpy(xpost_string_get_pointer(ctx, str), nostringval, sizeof(nostringval)-1);
             str.comp_.sz = sizeof(nostringval)-1;
-            break;
-
-        case savetype:
-            if (str.comp_.sz < sizeof(ssave)-1)
-                return rangecheck;
-            memcpy(xpost_string_get_pointer(ctx, str), ssave, sizeof(ssave)-1);
-            str.comp_.sz = sizeof(ssave)-1;
-            break;
-
-        case marktype:
-            if (str.comp_.sz < sizeof(smark)-1)
-                return rangecheck;
-            memcpy(xpost_string_get_pointer(ctx, str), smark, sizeof(smark)-1);
-            str.comp_.sz = sizeof(smark)-1;
             break;
 
         case booleantype:

--- a/src/lib/xpost_op_type.c
+++ b/src/lib/xpost_op_type.c
@@ -359,48 +359,16 @@ int NRScvrs(Xpost_Context *ctx,
     return 0;
 }
 
-/* helper function: fill string with integer */
-static
-int conv_integ(real num,
-               char *s,
-               int n)
-{
-    int off;
-    if (num < 10)
-    {
-        *s = ((int)num) + '0';
-        return 1;
-    }
-    off = conv_integ((real)(num/10), s, n);
-    if ((off == n) || (off == -1)) return -1;
-    s[off] = (((int)num)%10) + '0';
-    return off + 1;
-}
-
-/* helper function: fill string with fraction */
-static
-int conv_frac (real num,
-               char *s,
-               int n)
-{
-    real integ, frac;
-    num *= 10;
-    integ = (real)floor(num);
-    frac = num - integ;
-    *s = (int)integ + '0';
-    //if (num == 0.0) return 1;
-    if (num < 0.0001) return 1;
-    return 1 + conv_frac(frac, s+1, n-1);
-}
-
 /* helper function: fill string with real decimal representation */
 static
 int conv_real (real num,
                char *s,
                int n)
 {
-    int off = 0;
-    real integ, frac;
+    char buf[40];
+    double d = (double)num;
+    int prec, e, len;
+
     if (n == 0) return -1;
     if (isinf(num))
     {
@@ -414,20 +382,54 @@ int conv_real (real num,
         memcpy(s, "nan", 3);
         return 3;
     }
-    if (num < 0)
+    if (d == 0.0)
     {
-        num = (real)fabs(num);
-        s[off++] = '-';
+        if (n < 3) return -1;
+        memcpy(s, "0.0", 3);
+        return 3;
     }
-    integ = (real)floor(num);
-    frac = num - integ;
-    off += conv_integ(integ, s+off, n);
-    s[off++] = '.';
-    off += conv_frac(frac, s+off, n-off);
-    return off;
-}
 
-/* any string  cvs  string
+    /* the shortest decimal that reads back to the same value, as the
+       reference interpreters produce. Find the fewest significant
+       digits whose round trip is exact, take the decimal exponent from
+       that same scientific rendering (not from log10, which rounds the
+       wrong way at the powers of ten), then present it as the
+       reference does: fixed notation while the magnitude sits between
+       1e-4 and 1e6, scientific outside that band. A fixed value that
+       comes out whole gains a ".0" so it scans back as a real. */
+    for (prec = 1; prec < 17; prec++)
+    {
+        snprintf(buf, sizeof buf, "%.*e", prec - 1, d);
+        if ((real)strtod(buf, NULL) == num)
+            break;
+    }
+    {
+        char *ep = strchr(buf, 'e');
+        e = ep ? atoi(ep + 1) : 0;
+    }
+
+    if (e >= -4 && e < 6)
+    {
+        int dec = prec - 1 - e;
+        if (dec < 0) dec = 0;
+        snprintf(buf, sizeof buf, "%.*f", dec, d);
+        if (dec == 0)
+        {
+            len = (int)strlen(buf);
+            if (len + 2 < (int)sizeof buf)
+            { buf[len] = '.'; buf[len + 1] = '0'; buf[len + 2] = 0; }
+        }
+    }
+    else
+    {
+        snprintf(buf, sizeof buf, "%.*e", prec - 1, d);
+    }
+
+    len = (int)strlen(buf);
+    if (len > n) return -1;
+    memcpy(s, buf, len);
+    return len;
+}/* any string  cvs  string
    convert any object to string representation */
 static
 int AScvs (Xpost_Context *ctx,

--- a/src/lib/xpost_op_type.c
+++ b/src/lib/xpost_op_type.c
@@ -436,7 +436,7 @@ int AScvs (Xpost_Context *ctx,
            Xpost_Object any,
            Xpost_Object str)
 {
-    char nostringval[] = "-nostringval-";
+    char nostringval[] = "--nostringval--";
     char strue[] = "true";
     char sfalse[] = "false";
     char smark[] = "-mark-";

--- a/src/lib/xpost_op_type.c
+++ b/src/lib/xpost_op_type.c
@@ -239,6 +239,16 @@ int _string_to_number(const char *t,
         return typecheck;
     if (errno == ERANGE)
         return limitcheck;
+    /* strtod also accepts forms outside PostScript number syntax -- a C-style
+       0x hexadecimal prefix and inf/nan; PostScript treats those as typecheck */
+    {
+        const char *p;
+        for (p = t; p < end; p++)
+            if (*p == 'x' || *p == 'X')
+                return typecheck;
+    }
+    if (!(num == num) || num > 1e308 || num < -1e308)
+        return typecheck;
     *out = num;
     return 0;
 }

--- a/src/lib/xpost_op_type.c
+++ b/src/lib/xpost_op_type.c
@@ -165,11 +165,23 @@ int Awcheck(Xpost_Context *ctx,
 /* number  cvi  int
    convert number to integer */
 static
+/* Largest and smallest values the integer type holds, as doubles, for range
+   checks; the ternary folds to a constant. */
+#define XPOST_INTEGER_HI_D ((sizeof(integer) >= 8) ? 9223372036854775807.0 : 2147483647.0)
+#define XPOST_INTEGER_LO_D ((sizeof(integer) >= 8) ? -9223372036854775808.0 : -2147483648.0)
+
 int Ncvi(Xpost_Context *ctx,
          Xpost_Object n)
 {
     if (xpost_object_get_type(n) == realtype)
-        n = xpost_int_cons((integer)n.real_.val);
+    {
+        double v = (double)n.real_.val;
+        /* cvi truncates toward zero; PLRM raises rangecheck when the real is
+           too large to represent as an integer */
+        if (v >= XPOST_INTEGER_HI_D + 1.0 || v <= XPOST_INTEGER_LO_D - 1.0)
+            return rangecheck;
+        n = xpost_int_cons((integer)v);
+    }
     xpost_stack_push(ctx->lo, ctx->os, n);
     return 0;
 }
@@ -245,10 +257,11 @@ int Scvi(Xpost_Context *ctx,
     free(t);
     if (ret)
         return ret;
-    if (dbl >= LONG_MAX || dbl <= LONG_MIN)
-        return limitcheck;
+    /* a numeral that does not fit the integer type is rangecheck (PLRM cvi) */
+    if (dbl >= XPOST_INTEGER_HI_D + 1.0 || dbl <= XPOST_INTEGER_LO_D - 1.0)
+        return rangecheck;
 
-    xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons((long)dbl));
+    xpost_stack_push(ctx->lo, ctx->os, xpost_int_cons((integer)dbl));
     return 0;
 }
 

--- a/src/lib/xpost_operator.c
+++ b/src/lib/xpost_operator.c
@@ -408,7 +408,10 @@ Xpost_Object xpost_operator_cons(Xpost_Context *ctx,
 
     vmmode=ctx->vmmode;
     ctx->vmmode = GLOBAL;
-    nm = xpost_name_cons(ctx, name);
+    /* the optab records names by their global index: a locally
+       interned name with the same numeric index would alias a
+       different operator entirely */
+    nm = xpost_name_cons_global(ctx, name);
     if (xpost_object_get_type(nm) == invalidtype)
         return invalid;
     ctx->vmmode = vmmode;

--- a/src/lib/xpost_operator.c
+++ b/src/lib/xpost_operator.c
@@ -639,7 +639,12 @@ int xpost_operator_exec(Xpost_Context *ctx,
         if (ct < sp[i].in)
         {
             pass = 0;
-            err = stackunderflow;
+            /* a higher-arity signature that lacks operands must not mask a
+               type mismatch already found against a signature whose arity
+               was satisfied: a wrong-typed operand is a typecheck, not a
+               stackunderflow */
+            if (err != typecheck)
+                err = stackunderflow;
             continue;
         }
 

--- a/src/lib/xpost_operator.c
+++ b/src/lib/xpost_operator.c
@@ -63,6 +63,19 @@ Xpost_Object _promote_integer_to_real(Xpost_Object o)
     return xpost_real_cons((real)o.int_.val);
 }
 
+/* Record that operand at top-down index idx was coerced from the integer orig,
+   so an error can restore the original the program pushed (PLRM 3.11). Called
+   only when a coercion actually happens, so it is a no-op for the usual case. */
+static void _op_restore_note(Xpost_Context *ctx, int idx, Xpost_Object orig)
+{
+    if (ctx->op_restore_n < (int)(sizeof ctx->op_restore_idx))
+    {
+        ctx->op_restore_idx[ctx->op_restore_n] = (unsigned char)idx;
+        ctx->op_restore_val[ctx->op_restore_n] = orig;
+        ctx->op_restore_n++;
+    }
+}
+
 /* copied from the header file for reference:
    typedef struct Xpost_Signature {
    int (*fp)(Xpost_Context *ctx);
@@ -137,6 +150,7 @@ int _stack_float(Xpost_Context *ctx)
         case invalidtype:
             return stackunderflow;
         case integertype:
+            _op_restore_note(ctx, 0, s0);
             xpost_stack_topdown_replace(ctx->lo, ctx->os, 0, s0 = _promote_integer_to_real(s0));
             /* fallthrough */
         case realtype:
@@ -214,6 +228,7 @@ int _stack_float_float(Xpost_Context *ctx)
         case invalidtype:
             return stackunderflow;
         case integertype:
+            _op_restore_note(ctx, 0, s0);
             xpost_stack_topdown_replace(ctx->lo, ctx->os, 0, s0 = _promote_integer_to_real(s0));
             /* fallthrough */
         case realtype:
@@ -223,6 +238,7 @@ int _stack_float_float(Xpost_Context *ctx)
                 case invalidtype:
                     return stackunderflow;
                 case integertype:
+                    _op_restore_note(ctx, 1, s1);
                     xpost_stack_topdown_replace(ctx->lo, ctx->os, 1, s1 = _promote_integer_to_real(s1));
                     /* fallthrough */
                 case realtype:
@@ -585,6 +601,8 @@ int xpost_operator_exec(Xpost_Context *ctx,
     unsigned int optadr;
     int ret;
 
+    ctx->op_restore_n = 0;
+
     ret = xpost_memory_table_get_addr(ctx->gl,
                                       XPOST_MEMORY_TABLE_SPECIAL_OPERATOR_TABLE, &optadr);
     if (!ret)
@@ -643,6 +661,7 @@ int xpost_operator_exec(Xpost_Context *ctx,
             {
                 if (xpost_object_get_type(el) == integertype)
                 {
+                    _op_restore_note(ctx, j, el);
                     if (!xpost_stack_topdown_replace(ctx->lo, ctx->os, j, el = _promote_integer_to_real(el)))
                         return unregistered;
                     continue;
@@ -661,6 +680,12 @@ int xpost_operator_exec(Xpost_Context *ctx,
 
         if (pass) goto call;
     }
+    /* no signature matched: a rejected trial may have coerced an operand from
+       integer to real before failing. The operator never ran, so the operands
+       are still on the stack; put back the integers the program pushed. */
+    for (i = 0; i < ctx->op_restore_n; i++)
+        xpost_stack_topdown_replace(ctx->lo, ctx->os,
+                ctx->op_restore_idx[i], ctx->op_restore_val[i]);
     return err;
 
   call:

--- a/src/lib/xpost_operator.h
+++ b/src/lib/xpost_operator.h
@@ -64,8 +64,20 @@
 
 /**
  * @brief a "generic" function pointer for operator functions
+ *
+ * The argument list is deliberately left unspecified: every operator has a
+ * different concrete signature, and each is cast to this one type and invoked
+ * through it. A (void) prototype would forbid those calls, so the empty list
+ * is required here and -Wstrict-prototypes is suppressed only at this site.
  */
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wstrict-prototypes"
+#endif
 typedef int (*Xpost_Op_Func)();
+#if defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif
 
 /**
  * @brief operator signature structure

--- a/src/lib/xpost_save.c
+++ b/src/lib/xpost_save.c
@@ -142,8 +142,19 @@ unsigned xpost_save_ent_is_saved(Xpost_Memory_File *mem,
     llev = (tab->tab[ent].mark & XPOST_MEMORY_TABLE_MARK_DATA_LOWLEVEL_MASK)
         >> XPOST_MEMORY_TABLE_MARK_DATA_LOWLEVEL_OFFSET;
 
-    return llev < sav.save_.lev ?
-        tlev == sav.save_.lev : 1;
+    /* An object must be backed up at the current save if it was born
+       before that save established its level and has not been backed up
+       here yet. create_snapshot_object records .lev as the stack count
+       taken *before* the save pushes itself, so an object whose birth
+       count llev equals sav.lev was created just before this save and
+       still needs protecting: the test is llev <= sav.lev, not < (the
+       missing boundary was the off-by-one that left a top-level
+       save/restore from reverting anything). Backups stamp tlev with
+       sav.lev + 1 (see save_save_ent) so the "already backed up" marker
+       cannot be confused with an object's birth stamp, which equals its
+       birth count and is therefore <= sav.lev for anything protectable. */
+    return llev <= (unsigned int)sav.save_.lev ?
+        (tlev == (unsigned int)sav.save_.lev + 1) : 1;
 }
 
 /* make a clone of ent, return new ent */
@@ -218,7 +229,9 @@ int xpost_save_save_ent(Xpost_Memory_File *mem,
         XPOST_LOG_ERR("cannot find table for ent %u", ent);
         return 0;
     }
-    tlev = sav.save_.lev;
+    tlev = sav.save_.lev + 1; /* +1 keeps this "backed up here" marker
+                                 distinct from a birth stamp; see the note
+                                 in xpost_save_ent_is_saved */
     tab->tab[ent].mark &= ~XPOST_MEMORY_TABLE_MARK_DATA_TOPLEVEL_MASK; // clear TLEV field
     tab->tab[ent].mark |= (tlev << XPOST_MEMORY_TABLE_MARK_DATA_TOPLEVEL_OFFSET);  // set TLEV field
 
@@ -285,6 +298,19 @@ void xpost_save_restore_snapshot(Xpost_Memory_File *mem)
         hold = tab->tab[sent].adr;                 // tmp = src
         tab->tab[sent].adr = tab->tab[cent].adr;  // src = cpy
         tab->tab[cent].adr = hold;                 // cpy = tmp
+
+        /* the object is back to its pre-save contents, so clear its
+           "backed up here" marker (reset tlev to its birth level llev).
+           Otherwise a later save that reuses this now-vacated level
+           would see the stale marker and skip the backup, and its
+           restore would not revert the object. */
+        {
+            unsigned int llv =
+                (tab->tab[sent].mark & XPOST_MEMORY_TABLE_MARK_DATA_LOWLEVEL_MASK)
+                >> XPOST_MEMORY_TABLE_MARK_DATA_LOWLEVEL_OFFSET;
+            tab->tab[sent].mark &= ~XPOST_MEMORY_TABLE_MARK_DATA_TOPLEVEL_MASK;
+            tab->tab[sent].mark |= (llv << XPOST_MEMORY_TABLE_MARK_DATA_TOPLEVEL_OFFSET);
+        }
     }
     //xpost_stack_free(mem, sav.save_.stk);
 }

--- a/src/lib/xpost_save.c
+++ b/src/lib/xpost_save.c
@@ -100,7 +100,22 @@ Xpost_Object xpost_save_create_snapshot_object(Xpost_Memory_File *mem)
         return null;
     }
     v.save_.lev = xpost_stack_count(mem, vs);
-    xpost_stack_init(mem, &v.save_.stk);
+    if (mem->free_substack)
+    {
+        /* reuse the record stack a previous restore parked. It is a single
+           segment (only those are pooled) and already unreferenced; empty
+           it before handing it out. */
+        Xpost_Stack *s;
+        v.save_.stk = mem->free_substack;
+        mem->free_substack = 0;
+        s = (Xpost_Stack *)(mem->base + v.save_.stk);
+        s->top = 0;
+        s->prevseg = v.save_.stk;
+    }
+    else
+    {
+        xpost_stack_init(mem, &v.save_.stk);
+    }
     xpost_stack_push(mem, vs, v);
     return v;
 }
@@ -328,6 +343,23 @@ void xpost_save_restore_snapshot(Xpost_Memory_File *mem)
                 >> XPOST_MEMORY_TABLE_MARK_DATA_LOWLEVEL_OFFSET;
             tab->tab[sent].mark &= ~XPOST_MEMORY_TABLE_MARK_DATA_TOPLEVEL_MASK;
             tab->tab[sent].mark |= (llv << XPOST_MEMORY_TABLE_MARK_DATA_TOPLEVEL_OFFSET);
+        }
+    }
+
+    /* The record stack is now empty and, with its save object popped, wholly
+       unreferenced. It is a raw file allocation the collector cannot reclaim
+       (xpost_stack_free is a broken stub, hence the dead line below), so a
+       save/restore-heavy job would leak one per save level. Park a single
+       one for the next save to reuse. Only single-segment stacks are pooled
+       -- the overwhelming common case, and it keeps reuse a plain top reset;
+       a stack that grew across segments is left as it was. */
+    {
+        Xpost_Stack *sub = (Xpost_Stack *)(mem->base + sav.save_.stk);
+        if (mem->free_substack == 0 && sub->nextseg == 0)
+        {
+            sub->top = 0;
+            sub->prevseg = sav.save_.stk;
+            mem->free_substack = sav.save_.stk;
         }
     }
     //xpost_stack_free(mem, sav.save_.stk);

--- a/src/lib/xpost_save.c
+++ b/src/lib/xpost_save.c
@@ -235,9 +235,6 @@ int xpost_save_save_ent(Xpost_Memory_File *mem,
     tab->tab[ent].mark &= ~XPOST_MEMORY_TABLE_MARK_DATA_TOPLEVEL_MASK; // clear TLEV field
     tab->tab[ent].mark |= (tlev << XPOST_MEMORY_TABLE_MARK_DATA_TOPLEVEL_OFFSET);  // set TLEV field
 
-    o.saverec_.tag = tag;
-    o.saverec_.pad = pad;
-    o.saverec_.src = ent;
     cpy = _copy_ent(mem, ent);
     if (cpy == 0)
     {
@@ -245,7 +242,13 @@ int xpost_save_save_ent(Xpost_Memory_File *mem,
         return 0;
     }
 
-    o.saverec_.cpy = cpy;
+    /* src and cpy may be wider than a word; their high bits ride in the
+       tag (see XPOST_SAVEREC_TAG in xpost_save.h). pad keeps its meaning:
+       an array's element count for the collector, zero otherwise. */
+    o.saverec_.tag = XPOST_SAVEREC_TAG(tag, ent, cpy);
+    o.saverec_.pad = pad;
+    o.saverec_.src = (word)ent;
+    o.saverec_.cpy = (word)cpy;
     xpost_stack_push(mem, sav.save_.stk, o);
     return 1;
 }
@@ -282,8 +285,8 @@ void xpost_save_restore_snapshot(Xpost_Memory_File *mem)
         rec = xpost_stack_pop(mem, sav.save_.stk);
         if (xpost_object_get_type(rec) == invalidtype)
             return;
-        sent = rec.saverec_.src;
-        cent = rec.saverec_.cpy;
+        sent = XPOST_SAVEREC_SRC(rec);
+        cent = XPOST_SAVEREC_CPY(rec);
         XPOST_LOG_INFO("replacing ent %u with copy ent %u", sent, cent);
         if (sent >= tab->nextent)
         {

--- a/src/lib/xpost_save.c
+++ b/src/lib/xpost_save.c
@@ -40,6 +40,7 @@
 #include "xpost_memory.h"  /* save/restore works with mtabs */
 #include "xpost_object.h"  /* save/restore examines objects */
 #include "xpost_stack.h"  /* save/restore manipulates (internal) stacks */
+#include "xpost_free.h"  /* restore discards the backup copies it made */
 #include "xpost_error.h"
 
 #include "xpost_save.h"  /* double-check prototypes */
@@ -301,6 +302,20 @@ void xpost_save_restore_snapshot(Xpost_Memory_File *mem)
         hold = tab->tab[sent].adr;                 // tmp = src
         tab->tab[sent].adr = tab->tab[cent].adr;  // src = cpy
         tab->tab[cent].adr = hold;                 // cpy = tmp
+
+        /* The copy has done its job. After the swap it holds the
+           discarded post-save contents and the popped saverec was its
+           only reference, so return its entity and storage to the free
+           list -- the "explicit discarding by restore" the design calls
+           for (doc/NEWINTERNALS). Without it every composite modified
+           under a save leaks an entity until the next collection, which
+           the collector only runs on a byte/entity threshold; a job with
+           enough save/restore traffic drives the entity counter up
+           needlessly. Freeing here is safe: restore has no collection
+           safe point, nothing else names cent, and the collector's sweep
+           rebuilds the free list from the mark bits so a freed entity is
+           never double-listed. */
+        (void)xpost_free_memory_ent(mem, cent);
 
         /* the object is back to its pre-save contents, so clear its
            "backed up here" marker (reset tlev to its birth level llev).

--- a/src/lib/xpost_save.c
+++ b/src/lib/xpost_save.c
@@ -314,9 +314,22 @@ void xpost_save_restore_snapshot(Xpost_Memory_File *mem)
             XPOST_LOG_ERR("cannot find table for ent %u", cent);
             return;
         }
+        /* Exchange the whole storage identity, not the address alone: a
+           composite that GREW under the save (dicgrow reallocates and gives
+           the object a larger sz) otherwise keeps its grown sz while pointing
+           at the smaller backup allocation. Its byte range then overruns the
+           entities that follow, and reusing or writing it corrupts them. Swap
+           sz and used alongside adr so the reverted object and the discarded
+           copy each carry a consistent (adr, sz, used) triple. */
         hold = tab->tab[sent].adr;                 // tmp = src
         tab->tab[sent].adr = tab->tab[cent].adr;  // src = cpy
         tab->tab[cent].adr = hold;                 // cpy = tmp
+        hold = tab->tab[sent].sz;
+        tab->tab[sent].sz = tab->tab[cent].sz;
+        tab->tab[cent].sz = hold;
+        hold = tab->tab[sent].used;
+        tab->tab[sent].used = tab->tab[cent].used;
+        tab->tab[cent].used = hold;
 
         /* The copy has done its job. After the swap it holds the
            discarded post-save contents and the popped saverec was its

--- a/src/lib/xpost_save.h
+++ b/src/lib/xpost_save.h
@@ -88,4 +88,38 @@ int xpost_save_save_ent(Xpost_Memory_File *mem, unsigned tag, unsigned pad, unsi
  */
 void xpost_save_restore_snapshot(Xpost_Memory_File *mem);
 
+/* A saverec records two entity numbers, src and cpy. An entity number
+   can exceed the 16-bit `word` that saverec_.src / saverec_.cpy provide
+   (see XPOST_OBJECT_COMP_MAX_ENT, which reaches 2^20 in the small-object
+   build): a bare-word store would truncate the high bits, and restore
+   and the garbage collector would then revert -- or mark -- the wrong
+   allocation. A saverec's tag word carries only its small type value
+   (saverecs have no access or flag bits), so the high parts of both
+   entity numbers ride in that tag above the 5-bit type field: src's high
+   XPOST_OBJECT_TAG_EXTRA_BITS_SIZE bits, then cpy's. `pad` is left alone
+   (arrays store their element count there for the collector). In the
+   large-object build a `word` already spans the whole entity number, so
+   the tag holds the bare type and no bits are borrowed. Saverecs are
+   only ever read through these accessors, never through xpost_object_get_ent. */
+#define XPOST_SAVEREC_ENT_HI_BITS  XPOST_OBJECT_TAG_EXTRA_BITS_SIZE
+#define XPOST_SAVEREC_ENT_HI_MASK  ((1u << XPOST_SAVEREC_ENT_HI_BITS) - 1u)
+#define XPOST_SAVEREC_SRC_HI_SHIFT 5u  /* first bit above the 5-bit type field */
+#define XPOST_SAVEREC_CPY_HI_SHIFT (XPOST_SAVEREC_SRC_HI_SHIFT + XPOST_SAVEREC_ENT_HI_BITS)
+
+#define XPOST_SAVEREC_TYPE(o) ((o).saverec_.tag & XPOST_OBJECT_TAG_DATA_TYPE_MASK)
+
+#ifdef WANT_LARGE_OBJECT
+# define XPOST_SAVEREC_TAG(type, src, cpy) ((word)(type))
+# define XPOST_SAVEREC_SRC(o) ((unsigned int)(o).saverec_.src)
+# define XPOST_SAVEREC_CPY(o) ((unsigned int)(o).saverec_.cpy)
+#else
+# define XPOST_SAVEREC_TAG(type, src, cpy) ((word)((unsigned int)(type) \
+    | ((((src) >> (8u * sizeof(word))) & XPOST_SAVEREC_ENT_HI_MASK) << XPOST_SAVEREC_SRC_HI_SHIFT) \
+    | ((((cpy) >> (8u * sizeof(word))) & XPOST_SAVEREC_ENT_HI_MASK) << XPOST_SAVEREC_CPY_HI_SHIFT)))
+# define XPOST_SAVEREC_SRC(o) ((unsigned int)(o).saverec_.src \
+    | ((((unsigned int)(o).saverec_.tag >> XPOST_SAVEREC_SRC_HI_SHIFT) & XPOST_SAVEREC_ENT_HI_MASK) << (8u * sizeof(word))))
+# define XPOST_SAVEREC_CPY(o) ((unsigned int)(o).saverec_.cpy \
+    | ((((unsigned int)(o).saverec_.tag >> XPOST_SAVEREC_CPY_HI_SHIFT) & XPOST_SAVEREC_ENT_HI_MASK) << (8u * sizeof(word))))
+#endif
+
 #endif

--- a/src/lib/xpost_stack.c
+++ b/src/lib/xpost_stack.c
@@ -235,6 +235,39 @@ int xpost_stack_topdown_replace(Xpost_Memory_File *mem,
 #endif
 }
 
+int xpost_stack_topdown_find_type(Xpost_Memory_File *mem,
+                                  unsigned int stackadr,
+                                  int type,
+                                  Xpost_Object *out)
+{
+    unsigned char *base = mem->base;
+    Xpost_Stack *root = (Xpost_Stack *)(base + stackadr);
+    Xpost_Stack *seg = (Xpost_Stack *)(base + root->prevseg); /* top segment */
+    int idx = 0;
+
+    /* Walk the segment chain once from the top rather than calling
+       topdown_fetch per index -- each of those re-walks the chain, so a scan
+       of the whole stack was O(n^2). Here each element is visited once. */
+    for (;;)
+    {
+        int k;
+        for (k = (int)seg->top; k-- > 0; )
+        {
+            if ((int)xpost_object_get_type(seg->data[k]) == type)
+            {
+                if (out)
+                    *out = seg->data[k];
+                return idx;
+            }
+            idx++;
+        }
+        if (seg == root)
+            break;
+        seg = (Xpost_Stack *)(base + seg->prevseg);
+    }
+    return -1;
+}
+
 Xpost_Object xpost_stack_bottomup_fetch(Xpost_Memory_File *mem,
                                         unsigned int stackadr,
                                         int idx)

--- a/src/lib/xpost_stack.h
+++ b/src/lib/xpost_stack.h
@@ -122,6 +122,17 @@ int xpost_stack_topdown_replace(Xpost_Memory_File *mem,
                                 Xpost_Object obj);
 
 /**
+ * @brief Top-down index of the topmost element whose object type is @p type,
+ * or -1 if none. When @p out is non-NULL and a match is found it receives
+ * that element. One top-down segment pass: O(elements scanned), where a loop
+ * of xpost_stack_topdown_fetch per index would be O(n^2) on a segmented stack.
+ */
+int xpost_stack_topdown_find_type(Xpost_Memory_File *mem,
+                                  unsigned stackadr,
+                                  int type,
+                                  Xpost_Object *out);
+
+/**
  * @brief Index the stack from the bottom up, fetching object.
  */
 Xpost_Object xpost_stack_bottomup_fetch(Xpost_Memory_File *mem,

--- a/src/lib/xpost_string.c
+++ b/src/lib/xpost_string.c
@@ -76,6 +76,14 @@ Xpost_Object xpost_string_cons_memory(Xpost_Memory_File *mem,
             return null;
         }
     }
+    else
+    {
+        /* the PLRM specifies zero-initialized strings; storage reused
+           from the free list still holds the previous tenant's bytes */
+        unsigned int adr;
+        if (xpost_memory_table_get_addr(mem, ent, &adr))
+            memset(mem->base + adr, 0, sz);
+    }
     o.tag = stringtype | (XPOST_OBJECT_TAG_ACCESS_UNLIMITED << XPOST_OBJECT_TAG_DATA_FLAG_ACCESS_OFFSET);
     o.comp_.sz = sz;
     //o.comp_.ent = ent;

--- a/src/lib/xpost_string.c
+++ b/src/lib/xpost_string.c
@@ -133,6 +133,8 @@ int xpost_string_put_memory(Xpost_Memory_File *mem,
     byte b = c;
     int ret;
 
+    if (i < 0 || i >= s.comp_.sz)
+        return rangecheck;
     ret = xpost_memory_put(mem, xpost_object_get_ent(s), s.comp_.off + i, 1, &b);
     if (!ret)
     {
@@ -162,6 +164,8 @@ int xpost_string_get_memory(Xpost_Memory_File *mem,
     byte b;
     int ret;
 
+    if (i < 0 || i >= s.comp_.sz)
+        return rangecheck;
     ret = xpost_memory_get(mem, xpost_object_get_ent(s), s.comp_.off + i, 1, &b);
     if (!ret)
     {

--- a/src/lib/xpost_string.c
+++ b/src/lib/xpost_string.c
@@ -32,6 +32,7 @@
 # include <config.h>
 #endif
 
+#include <stdio.h>
 #include <stdlib.h> /* size_t */
 #include <string.h> /* memcpy */
 

--- a/tests/counttomark_test.ps
+++ b/tests/counttomark_test.ps
@@ -42,6 +42,21 @@ dup /c get 3 eq (dict build c) assert
 length 3 eq (dict build length) assert
 << >> length 0 eq (empty dict build length) assert
 
+% --- construction past the 65535 composite-size cap raises a clean limitcheck ---
+% The array `[ ]` and dict `<< >>` constructors must reject an over-cap length
+% the same way the array/dict operators do -- with a single limitcheck -- rather
+% than let array_cons/dict_cons truncate the 16-bit size and then fault putting
+% each discarded element (a rangecheck error storm).
+{ [ 65536 { 0 } repeat ] } stopped
+    { $error /errorname get /limitcheck eq (array over cap -> limitcheck) assert }
+    { false (array over cap should raise limitcheck) assert } ifelse
+clear
+{ << 32768 { /k 0 } repeat >> } stopped   % 32768 pairs = 65536 objects
+    { $error /errorname get /limitcheck eq (dict over cap -> limitcheck) assert }
+    { false (dict over cap should raise limitcheck) assert } ifelse
+clear
+[ 65535 { 0 } repeat ] length 65535 eq (array at the cap still builds) assert
+
 % --- a count that spans several 1000-element stack segments ---
 mark 20000 { 7 } repeat counttomark 20000 eq (multi-segment counttomark) assert
 cleartomark

--- a/tests/counttomark_test.ps
+++ b/tests/counttomark_test.ps
@@ -1,0 +1,64 @@
+% counttomark and the [ ] / << >> constructors: correctness + O(n)
+% performance guard, run through `xpost -d null` by run-ps-test.sh; prints
+% SUCCESS iff every assertion holds. counttomark reports how many operands
+% sit above the topmost mark, and array `]` and dictionary `>>` construction
+% are built on it. A former implementation fetched each operand with a
+% top-down index lookup that re-walked the stack segments, so counttomark --
+% and therefore every `[ ... ]` and `<< ... >>` -- was O(n^2) in the number
+% of elements above the mark. A large array or dictionary literal then
+% dominated any job that assembled one. The big-build cases below must stay
+% fast; a return to O(n^2) surfaces as a run-time timeout in meson/make-check.
+% Outputs were checked value-for-value against Ghostscript.
+
+/faildict 2 dict def
+faildict /n 0 put
+/assert { % bool (name) . -
+    exch { pop } {
+        (FAIL: ) print print (\n) print
+        faildict /n 2 copy get 1 add put
+    } ifelse
+} bind def
+
+% --- counttomark counts only the elements above the topmost mark ---
+mark 10 20 30 counttomark 3 eq (counttomark counts 3) assert
+cleartomark
+mark counttomark 0 eq (counttomark of empty span is 0) assert
+cleartomark
+% a mark below another mark is not reached: count stops at the topmost mark
+mark 1 2 mark 7 8 9 counttomark 3 eq (counttomark stops at topmost mark) assert
+cleartomark cleartomark
+
+% --- array construction reverts the stack order correctly ---
+[ 10 20 30 ] dup 0 get 10 eq (array build elem 0) assert
+dup 1 get 20 eq (array build elem 1) assert
+dup 2 get 30 eq (array build elem 2) assert
+length 3 eq (array build length) assert
+[ ] length 0 eq (empty array build length) assert
+
+% --- dictionary construction pairs keys with values correctly ---
+<< /a 1 /b 2 /c 3 >> dup /a get 1 eq (dict build a) assert
+dup /b get 2 eq (dict build b) assert
+dup /c get 3 eq (dict build c) assert
+length 3 eq (dict build length) assert
+<< >> length 0 eq (empty dict build length) assert
+
+% --- a count that spans several 1000-element stack segments ---
+mark 20000 { 7 } repeat counttomark 20000 eq (multi-segment counttomark) assert
+cleartomark
+
+% performance guard: counttomark on a deep operand stack must stay O(n).
+% Arrays and dicts cap at 65535 elements here, so the [ ] / << >> paths
+% cannot themselves reach a punishing size; drive counttomark directly. A
+% mark with 200000 operands above it is counted 600 times: at O(n^2) each
+% count re-walks the segment chain per index (~50ms each) and the 600
+% repetitions stall for tens of seconds, timing the test out; at O(n) each
+% count is a single pass and the whole loop is well under a second. Each
+% count is also checked, so a miscount in the segment walk fails outright.
+mark 200000 { 0 } repeat
+600 { counttomark 200000 eq (repeated counttomark stays exact) assert } repeat
+cleartomark
+
+count 0 eq (operand stack is balanced) assert
+faildict /n get 0 eq { (SUCCESS\n) print } { faildict /n get =print ( failures\n) print } ifelse
+flush
+quit

--- a/tests/op_bytesavailable_test.ps
+++ b/tests/op_bytesavailable_test.ps
@@ -1,0 +1,21 @@
+% bytesavailable operator (PLRM 8.2), run through `xpost -d null` by
+% run-ps-test.sh: prints SUCCESS iff every assertion holds. Standard PostScript;
+% prints SUCCESS on Ghostscript too.
+%
+% For a seekable file bytesavailable is the number of bytes remaining; for a
+% non-seekable file, whose remaining count cannot be determined, it is -1.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+
+/f (bytesavail.scratch) (w) file def
+f (0123456789) writestring
+f closefile
+
+(bytesavail.scratch) (r) file
+dup bytesavailable 10 eq (a ten-byte file reports ten bytes available) assert
+dup 4 string readstring pop pop
+dup bytesavailable 6 eq (after reading four, six remain) assert
+closefile
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_closed_read_test.ps
+++ b/tests/op_closed_read_test.ps
@@ -1,0 +1,27 @@
+% Reading from a closed file reports end-of-data (an empty result and false)
+% rather than raising an error, matching Adobe Distiller and Ghostscript. Run
+% through `xpost -d null` by run-ps-test.sh; prints SUCCESS on Ghostscript too.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+/cr.f (closedread.scratch) (w) file def
+cr.f (Hi) writestring cr.f closefile
+/mkclosed { (closedread.scratch) (r) file dup closefile } def
+
+% every read-family operator returns false at once on a closed file
+mkclosed read not (read of a closed file is false) assert
+mkclosed 4 string readstring exch pop not (readstring of a closed file is false) assert
+mkclosed 4 string readstring pop length 0 eq (readstring of a closed file yields an empty string) assert
+mkclosed 4 string readhexstring exch pop not (readhexstring of a closed file is false) assert
+mkclosed 20 string readline exch pop not (readline of a closed file is false) assert
+
+% closing twice is harmless and status reports the file is closed
+mkclosed dup closefile status not (status of a closed file is false) assert
+
+% an open file still reads normally
+/g (closedread.scratch) (r) file def
+g read pop 72 eq (an open file still reads a byte) assert
+g 1 string readstring exch pop (an open file still reads a string) assert
+g closefile
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_control_test.ps
+++ b/tests/op_control_test.ps
@@ -1,0 +1,48 @@
+% Control operator compliance (PLRM 8.2), run through `xpost -d null` by
+% run-ps-test.sh: prints SUCCESS iff every assertion holds. Standard PostScript;
+% prints SUCCESS on Ghostscript too.
+%
+% Regression for the campaign fix: repeat with a negative count is rangecheck
+% (PLRM: the count is a "nonnegative integer"; rangecheck is the only Errors-list
+% code that fits an out-of-range count), not a silent no-op.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+/erris { 3 dict begin /tag exch def /want exch def
+    stopped { $error /errorname get want eq }{ false } ifelse
+    tag assert clear  % PLRM restores the failed operator's operands; drop them
+    end } def
+
+% --- repeat: nonnegative count; negative is rangecheck, zero is a no-op ---
+{ -1 { } repeat } /rangecheck (repeat of a negative count is rangecheck) erris
+{ -999 { (x) } repeat } /rangecheck (repeat of a large negative count is rangecheck) erris
+mark 0 { (nope) } repeat counttomark 0 eq exch pop (repeat 0 does nothing) assert
+/rc 0 def 4 { /rc rc 1 add def } repeat rc 4 eq (repeat n runs proc n times) assert
+/re 0 def
+10 { /re re 1 add def re 3 ge { exit } if } repeat re 3 eq (exit terminates repeat early) assert
+
+% --- if / ifelse ---
+true { 7 } if 7 eq (if true runs) assert
+false { 7 } if count 0 eq (if false runs nothing) assert
+true { 1 }{ 2 } ifelse 1 eq (ifelse true) assert
+false { 1 }{ 2 } ifelse 2 eq (ifelse false) assert
+{ 1 { 2 } if } /typecheck (if with a non-boolean is typecheck) erris
+
+% --- for: bounds, direction, empty range ---
+/s 0 def 1 1 5 { s add /s exch def } for s 15 eq (for sums 1..5) assert
+/s 0 def 5 -1 1 { s add /s exch def } for s 15 eq (for counts down) assert
+/n 0 def 1 1 0 { pop /n 1 def } for n 0 eq (an empty for range never runs) assert
+
+% --- loop / exit ---
+/k 0 def { /k k 1 add def k 5 ge { exit } if } loop k 5 eq (loop with exit) assert
+
+% --- exec ---
+{ 2 3 add } exec 5 eq (exec runs a procedure) assert
+3 exec 3 eq (exec of a non-procedure leaves it) assert
+
+% --- stopped / stop ---
+{ stop } stopped (stop is caught by stopped) assert
+{ 42 } stopped not (stopped is false when no stop occurs) assert
+{ 1 0 idiv } stopped (an error acts as stop under stopped) assert
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_control_test.ps
+++ b/tests/op_control_test.ps
@@ -45,4 +45,16 @@ false { 1 }{ 2 } ifelse 2 eq (ifelse false) assert
 { 42 } stopped not (stopped is false when no stop occurs) assert
 { 1 0 idiv } stopped (an error acts as stop under stopped) assert
 
+% for's control value is an integer when initial and increment are integers,
+% even if the limit is real: the type follows initial and increment, not the
+% limit (PLRM). A real increment does make the control value real.
+/intcount 0 def
+0 1 3.5 { type /integertype eq { /intcount intcount 1 add def } if } for
+intcount 4 eq (a real limit still yields integer control values) assert
+/sum 0 def 0 1 3.5 { sum add /sum exch def } for
+sum 6 eq (a real limit iterates the integers 0 through 3) assert
+/realcount 0 def
+0 0.5 1.0 { type /realtype eq { /realcount realcount 1 add def } if } for
+realcount 3 eq (a real increment yields real control values) assert
+
 failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_cvi_test.ps
+++ b/tests/op_cvi_test.ps
@@ -1,0 +1,21 @@
+% cvi / cvr number conversion (PLRM 8.2), run through `xpost -d null` by
+% run-ps-test.sh. Standard PostScript; prints SUCCESS on Ghostscript too.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+
+% cvi truncates toward zero
+3.7 cvi 3 eq (cvi of 3.7 is 3) assert
+-3.7 cvi -3 eq (cvi of -3.7 is -3) assert
+(3.3E1) cvi 33 eq (cvi of a real numeral string) assert
+(42) cvi 42 eq (cvi of an integer string) assert
+(16#ff) cvi 255 eq (cvi of a radix string) assert
+
+% cvi of an over-range real is rangecheck or a correctly-signed large integer,
+% never a wrap to the opposite sign
+{ 3000000000.0 cvi } stopped { $error /errorname get /rangecheck eq }{ 0 gt } ifelse
+(cvi of a large positive real does not wrap) assert
+{ -3000000000.0 cvi } stopped { $error /errorname get /rangecheck eq }{ -2000000000 lt } ifelse
+(cvi of a large negative real does not wrap) assert
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_cvi_test.ps
+++ b/tests/op_cvi_test.ps
@@ -4,6 +4,13 @@
 /failcount 0 def
 /assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
 
+% cvr/cvi of a string interpret PostScript number syntax; a C-style 0x hex
+% prefix or a non-number is a typecheck
+{ (0x10) cvr } stopped { $error /errorname get /typecheck eq }{ pop false } ifelse
+(cvr rejects a 0x hex prefix) assert
+{ (hello) cvr } stopped { $error /errorname get /typecheck eq }{ pop false } ifelse
+(cvr rejects a non-number) assert
+
 % cvi truncates toward zero
 3.7 cvi 3 eq (cvi of 3.7 is 3) assert
 -3.7 cvi -3 eq (cvi of -3.7 is -3) assert

--- a/tests/op_cvs_test.ps
+++ b/tests/op_cvs_test.ps
@@ -1,0 +1,28 @@
+% cvs produces a real string for integer, real, boolean, string, name and
+% operator objects; every other type yields --nostringval--. The debugging
+% == operator keeps its own -mark- rendering. Matches Adobe Distiller and
+% Ghostscript. Run through `xpost -d null` by run-ps-test.sh; prints SUCCESS
+% on Ghostscript too.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+/streq { 2 copy length exch length eq { eq } { pop pop false } ifelse } def
+/cvseq { 64 string cvs exch streq } def
+
+% types with a genuine string representation
+(42) 42 cvseq (cvs integer) assert
+(3.5) 3.5 cvseq (cvs real) assert
+(true) true cvseq (cvs boolean) assert
+(false) false cvseq (cvs boolean false) assert
+(hello) (hello) cvseq (cvs string) assert
+(foo) /foo cvseq (cvs name) assert
+(add) /add load cvseq (cvs operator) assert
+
+% every other type is --nostringval--
+(--nostringval--) mark cvseq (cvs mark) assert
+(--nostringval--) save cvseq (cvs save) assert
+(--nostringval--) [1 2 3] cvseq (cvs array) assert
+(--nostringval--) 1 dict cvseq (cvs dict) assert
+(--nostringval--) null cvseq (cvs null) assert
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_dispatch_typecheck_test.ps
+++ b/tests/op_dispatch_typecheck_test.ps
@@ -1,0 +1,29 @@
+% A wrong-typed operand is a typecheck even when the same operator carries a
+% higher-arity signature whose extra operands are absent: the missing operands
+% must not turn the type mismatch into a stackunderflow. PLRM and Adobe Distiller
+% raise typecheck for the matrix-building operators here; Ghostscript reports
+% stackunderflow, so this is an xpost/Distiller conformance check run through
+% `xpost -d null` and is NOT expected to print SUCCESS on Ghostscript. The
+% transform family, where Ghostscript agrees, is covered by op_matrix_gstate.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+/erris { 3 dict begin /tag exch def /want exch def
+    stopped { $error /errorname get want eq }{ false } ifelse tag assert clear end } def
+
+% the two-operand forms: a non-number operand is a typecheck, not masked into a
+% stackunderflow by the absent matrix of the three-operand form
+{ (x) 2 scale }     /typecheck (scale: a non-number operand is typecheck) erris
+{ 2 (y) scale }     /typecheck (scale: a non-number y operand is typecheck) erris
+{ (x) 2 translate } /typecheck (translate: a non-number operand is typecheck) erris
+{ (x) rotate }      /typecheck (rotate: a non-number angle is typecheck) erris
+
+% the matrix forms reject a non-number the same way
+{ (x) 2 [1 0 0 1 0 0] scale }     /typecheck (scale matrix form: a non-number is typecheck) erris
+{ (x) [1 0 0 1 0 0] rotate }      /typecheck (rotate matrix form: a non-number is typecheck) erris
+
+% genuinely too few operands is still a stackunderflow
+{ scale }           /stackunderflow (scale: no operands is stackunderflow) erris
+{ 5 translate }     /stackunderflow (translate: a single operand is stackunderflow) erris
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_error_restore_test.ps
+++ b/tests/op_error_restore_test.ps
@@ -1,0 +1,49 @@
+% Operand restoration on error (PLRM 3.11): after an operator errors, the operand
+% stack is restored to the state it was in when the operator began -- including
+% the integer types the program pushed, not the reals the dispatcher coerces them
+% to. Run through `xpost -d null` by run-ps-test.sh. Standard PostScript; prints
+% SUCCESS on Ghostscript too.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+/isint { type /integertype eq } def
+/isreal { type /realtype eq } def
+
+% div by zero: both operands restored as integers, deeper stack untouched
+clear 9 8 1 0 { div } stopped pop
+count 4 eq (div by zero leaves four operands) assert
+4 array astore /a exch def
+a 0 get 9 eq (deep operand untouched) assert
+a 3 get 0 eq (dividend value restored) assert  % a3 is top (the 0)
+a 3 get isint (top operand restored as integer, not real) assert
+a 2 get isint (second operand restored as integer, not real) assert
+
+% real numerator stays real, integer denominator stays integer
+clear 1.5 0 { div } stopped pop
+2 array astore /a exch def
+a 0 get isreal (real operand kept real) assert
+a 1 get isint (integer operand kept integer) assert
+
+% idiv / mod by zero (integer operators, no coercion) still restore cleanly
+clear 7 0 { idiv } stopped pop 2 array astore /a exch def
+a 0 get 7 eq a 1 get 0 eq and (idiv operands restored) assert
+a 0 get isint a 1 get isint and (idiv operands are integers) assert
+clear 7 0 { mod } stopped pop 2 array astore /a exch def
+a 0 get isint a 1 get isint and (mod operands are integers) assert
+
+% dispatch typecheck: a rejected float signature must not leave a coerced operand
+clear (x) 1 { add } stopped pop 2 array astore /a exch def
+a 1 get 1 eq (add: integer operand value kept) assert
+a 1 get isint (add: integer operand not coerced by the rejected float signature) assert
+clear 1 (x) { add } stopped pop 2 array astore /a exch def
+a 0 get isint (add: leading integer operand not coerced) assert
+
+% single-operand coercion: sqrt of a negative integer restores the integer
+clear -1 { sqrt } stopped pop
+dup -1 eq (sqrt: value restored) assert
+isint (sqrt: operand restored as integer) assert
+
+% successful coercing operator is unaffected
+clear 6 4 div 1.5 sub abs 1e-6 lt (div still works) assert
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_gstate_types_test.ps
+++ b/tests/op_gstate_types_test.ps
@@ -1,0 +1,40 @@
+% Graphics-state number parameters are reals (PLRM: these are real-valued),
+% matching Adobe Distiller and Ghostscript. Run through `xpost -d null` by
+% run-ps-test.sh. Standard PostScript; prints SUCCESS on Ghostscript too.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+/isreal { type /realtype eq } def
+
+initgraphics
+currentlinewidth isreal (default linewidth is real) assert
+currentflat isreal (default flat is real) assert
+currentgray isreal (default gray is real) assert
+currentmiterlimit isreal (default miterlimit is real) assert
+currentrgbcolor pop pop isreal (default rgb component is real) assert
+currentdash exch pop isreal (default dash offset is real) assert
+
+% integer arguments are coerced to real, as the reference interpreters do
+1 setgray currentgray isreal (setgray of an integer gives a real) assert
+1 0 0 setrgbcolor currentrgbcolor pop pop isreal (setrgbcolor of integers gives reals) assert
+0 0 0 1 setcmykcolor currentcmykcolor pop pop pop isreal (setcmykcolor of integers gives reals) assert
+3 setlinewidth currentlinewidth isreal (setlinewidth of an integer gives a real) assert
+5 setmiterlimit currentmiterlimit isreal (setmiterlimit of an integer gives a real) assert
+2 setflat currentflat isreal (setflat of an integer gives a real) assert
+[2 2] 1 setdash currentdash exch pop isreal (setdash integer offset gives a real) assert
+
+% the numeric value is preserved
+initgraphics 0.5 setgray currentgray 0.5 sub abs 1e-6 lt (gray value preserved) assert
+3 setlinewidth currentlinewidth 3 sub abs 1e-6 lt (linewidth value preserved) assert
+
+% colour components outside [0,1] are clamped to the nearest bound (PLRM)
+-1 setgray currentgray 0.0 eq (setgray clamps a negative component) assert
+1.5 setgray currentgray 1.0 eq (setgray clamps an over-range component) assert
+-0.5 0 0 setrgbcolor currentrgbcolor pop pop 0.0 eq (setrgbcolor clamps a negative component) assert
+2 0 0 0 setcmykcolor currentcmykcolor pop pop pop 1.0 eq (setcmykcolor clamps an over-range component) assert
+0.5 -0.5 0.5 sethsbcolor currenthsbcolor pop exch pop 0.0 eq (sethsbcolor clamps a negative saturation) assert
+% hue is clamped, not wrapped: below 0 and above 1 both land on red
+-0.25 1 1 sethsbcolor currentrgbcolor pop pop 1.0 eq (a negative hue clamps to red) assert
+1.25 1 1 sethsbcolor currentrgbcolor pop pop 1.0 eq (an over-range hue clamps to red) assert
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_index_type_test.ps
+++ b/tests/op_index_type_test.ps
@@ -1,0 +1,37 @@
+% get and put require an integer index for arrays and strings: a real index
+% is a typecheck, as it is on Adobe Distiller and Ghostscript. A dictionary
+% key may be any type, so a real key is still valid; an array element may be
+% any object, so a real value in a put is still valid, while a string holds
+% bytes, so a real value in a string put is a typecheck. Run through
+% `xpost -d null` by run-ps-test.sh; prints SUCCESS on Ghostscript too.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+/erris { 3 dict begin /tag exch def /want exch def
+    stopped { $error /errorname get want eq }{ false } ifelse tag assert clear end } def
+
+% integer indices work as before
+[10 20 30] 1 get 20 eq (array get by integer) assert
+(ABC) 1 get 66 eq (string get by integer) assert
+[0 0 0] dup 1 9 put 1 get 9 eq (array put by integer) assert
+(abc) dup 0 88 put 0 get 88 eq (string put by integer) assert
+
+% a real index is a typecheck for arrays and strings
+{ [1 2 3] 1.0 get } /typecheck (array get by a real index is typecheck) erris
+{ [1 2 3] 1.5 get } /typecheck (array get by a fractional index is typecheck) erris
+{ [0 0 0] 1.0 9 put } /typecheck (array put by a real index is typecheck) erris
+{ (abc) 1.0 get } /typecheck (string get by a real index is typecheck) erris
+{ (abc) 1.0 65 put } /typecheck (string put by a real index is typecheck) erris
+
+% a string byte must be an integer; a real value is a typecheck
+{ (abc) 0 65.0 put } /typecheck (string put of a real value is typecheck) erris
+{ (abc) 0 65.5 put } /typecheck (string put of a fractional value is typecheck) erris
+
+% an array element is any object, so a real value is accepted
+[0 0 0] dup 1 9.5 put 1 get 9.5 sub abs 1e-6 lt (array put of a real value is accepted) assert
+
+% a dictionary key may be any type, so a real key still works
+3 dict dup 2.5 7 put 2.5 get 7 eq (dict put and get by a real key) assert
+<</a 1>> dup 1.5 known not (dict known of an absent real key) assert
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_intoverflow_test.ps
+++ b/tests/op_intoverflow_test.ps
@@ -1,0 +1,24 @@
+% Integer-literal range (PLRM 3.3.2), run through `xpost -d null` by
+% run-ps-test.sh. Standard PostScript; prints SUCCESS on Ghostscript too.
+%
+% An integer constant beyond the implementation's integer range is converted to
+% a real, not wrapped. The value is checked rather than the type, since the
+% integer range itself is implementation-defined.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+
+% in-range values remain integers on any implementation
+42 type /integertype eq (small literal is an integer) assert
+2147483647 type /integertype eq (2^31-1 is an integer) assert
+
+% just past 2^31: must stay positive and near its true value (a wrap flips sign)
+2147483648 0 gt (2^31 literal is positive, not wrapped) assert
+2147483648 1000000 div 2147.483648 sub abs 1 lt (2^31 literal has its value) assert
+
+% far past the range
+100000000000 0 gt (1e11 literal is positive) assert
+100000000000 100000 div 1000000 sub abs 100 lt (1e11 literal has its value) assert
+-9999999999 0 lt (negative over-range literal stays negative) assert
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_math_test.ps
+++ b/tests/op_math_test.ps
@@ -44,6 +44,10 @@
 % --- div always real ---
 4 2 div 2.0 eq (4 2 div = 2.0 real) assert
 
+% --- sqrt: negative is rangecheck ---
+{ -1 sqrt } /rangecheck (sqrt of negative is rangecheck) erris
+16 sqrt 4.0 eq (sqrt 16 = 4) assert
+
 % --- round: ties go to the greater value (PLRM) ---
 3.2 round 3.0 eq (round 3.2 = 3) assert
 6.5 round 7.0 eq (round 6.5 = 7) assert

--- a/tests/op_math_test.ps
+++ b/tests/op_math_test.ps
@@ -1,0 +1,67 @@
+% Arithmetic/math operator compliance (PLRM 8.2), run through `xpost -d null` by
+% run-ps-test.sh: prints SUCCESS iff every assertion holds. Standard PostScript;
+% prints SUCCESS on Ghostscript too.
+%
+% Regression for three PLRM deviations found in the 8.2 compliance campaign:
+%   - mod by a zero divisor raised a hardware fault (SIGFPE) instead of the
+%     undefinedresult error PLRM mandates; INT_MIN mod/idiv -1 overflowed likewise
+%   - sqrt of a negative operand returned NaN instead of rangecheck
+%   - a truncated RAD_PER_DEG (0.0174533) skewed atan/sin/cos off the PLRM examples
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+/assertnear { 3 1 roll sub abs 1e-4 lt exch assert } def
+/erris { % { proc } /name (tag)  -> asserts proc raises error /name
+    3 dict begin
+    /tag exch def /want exch def
+    stopped { $error /errorname get want eq }{ false } ifelse
+    tag assert clear  % PLRM restores the failed operator's operands; drop them
+    end
+} def
+
+% --- mod / idiv / div: zero divisor is undefinedresult, not a crash ---
+{ 7 0 mod } /undefinedresult (mod by zero is undefinedresult) erris
+{ 7 0 idiv } /undefinedresult (idiv by zero is undefinedresult) erris
+{ 1 0 div } /undefinedresult (div by zero is undefinedresult) erris
+% surviving these proves no SIGFPE took the interpreter down
+(reached: interpreter survived the zero divisions) =
+
+% --- INT_MIN edge: no overflow fault ---
+{ -2147483648 -1 mod cvi } stopped { pop false }{ 0 eq } ifelse
+    (INT_MIN mod -1 is 0, no fault) assert
+{ -2147483648 -1 idiv } stopped { pop false }{ pop true } ifelse
+    (INT_MIN idiv -1 yields a value, no fault) assert
+
+% --- mod sign follows the dividend (PLRM examples) ---
+5 3 mod 2 eq (5 3 mod = 2) assert
+5 2 mod 1 eq (5 2 mod = 1) assert
+-5 3 mod -2 eq (-5 3 mod = -2) assert
+
+% --- idiv truncates toward zero ---
+3 2 idiv 1 eq (3 2 idiv = 1) assert
+-5 2 idiv -2 eq (-5 2 idiv = -2) assert
+
+% --- div always real ---
+4 2 div 2.0 eq (4 2 div = 2.0 real) assert
+
+% --- round: ties go to the greater value (PLRM) ---
+3.2 round 3.0 eq (round 3.2 = 3) assert
+6.5 round 7.0 eq (round 6.5 = 7) assert
+-4.8 round -5.0 eq (round -4.8 = -5) assert
+-6.5 round -6.0 eq (round -6.5 = -6, greater of -7/-6) assert
+99 round 99 eq (round of an integer stays integer-valued) assert
+
+% --- ceiling / floor / truncate ---
+3.2 ceiling 4.0 eq (ceiling 3.2 = 4) assert
+3.7 floor 3.0 eq (floor 3.7 = 3) assert
+-3.7 truncate -3.0 eq (truncate -3.7 = -3) assert
+
+% --- exp / ln / log ---
+2 3 exp 8.0 (2 3 exp = 8) assertnear
+1 ln 0.0 (ln 1 = 0) assertnear
+1000 log 3.0 (log 1000 = 3) assertnear
+
+% --- integer add overflowing to real (value; representation is impl-defined) ---
+2000000000 2000000000 add 4.0e9 (int add overflow -> real) assertnear
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_math_test.ps
+++ b/tests/op_math_test.ps
@@ -60,6 +60,18 @@
 3.7 floor 3.0 eq (floor 3.7 = 3) assert
 -3.7 truncate -3.0 eq (truncate -3.7 = -3) assert
 
+% --- atan (degrees 0..360), the PLRM examples exactly ---
+0 1 atan 0.0 (0 1 atan = 0) assertnear
+1 0 atan 90.0 (1 0 atan = 90) assertnear
+-100 0 atan 270.0 (-100 0 atan = 270) assertnear
+1 1 atan 45.0 (1 1 atan = 45) assertnear
+
+% --- sin / cos in degrees ---
+0 cos 1.0 (cos 0 = 1) assertnear
+90 sin 1.0 (sin 90 = 1) assertnear
+30 sin 0.5 (sin 30 = 0.5) assertnear
+60 cos 0.5 (cos 60 = 0.5) assertnear
+
 % --- exp / ln / log ---
 2 3 exp 8.0 (2 3 exp = 8) assertnear
 1 ln 0.0 (ln 1 = 0) assertnear

--- a/tests/op_matrix_gstate_test.ps
+++ b/tests/op_matrix_gstate_test.ps
@@ -7,6 +7,7 @@
 %     six-element array raised no error and read out of bounds; PLRM: rangecheck
 %   - setlinecap/setlinejoin outside 0..2, and setmiterlimit below 1, were
 %     accepted silently; PLRM: rangecheck
+%   - rotate built its matrix through a truncated RAD_PER_DEG
 
 /failcount 0 def
 /assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
@@ -39,6 +40,11 @@ dx 20.0 (dtransform x, no translation) assertnear dy 60.0 (dtransform y) assertn
                      5 get 3.0 (translate sets ty) assertnear
 2 3 matrix scale dup 0 get 2.0 (scale sets xx) assertnear
                  3 get 3.0 (scale sets yy) assertnear
+% rotate 90 -> [cos sin -sin cos 0 0] = [0 1 -1 0 0 0], within single-precision slack
+90 matrix rotate dup 0 get 0.0 (rotate 90 cos) assertnear
+                 dup 1 get 1.0 (rotate 90 sin) assertnear
+                 dup 2 get -1.0 (rotate 90 -sin) assertnear
+                 3 get 0.0 (rotate 90 cos again) assertnear
 [1 2 3 4 5 6] [1 0 0 1 0 0] matrix concatmatrix 0 get 1.0 (concatmatrix identity) assertnear
 
 % --- currentmatrix / setmatrix round-trip ---

--- a/tests/op_matrix_gstate_test.ps
+++ b/tests/op_matrix_gstate_test.ps
@@ -26,6 +26,13 @@ initgraphics
 { 20 60 [1 0 0 1] idtransform } /rangecheck (idtransform: short matrix is rangecheck) erris
 { [1 0 0 1] matrix invertmatrix } /rangecheck (invertmatrix: short matrix is rangecheck) erris
 
+% --- a bad-length destination matrix is rangecheck (was a silent arena overwrite) ---
+{ [1 2 3] identmatrix } /rangecheck (identmatrix: short destination is rangecheck) erris
+{ 90 [1 2 3] rotate } /rangecheck (rotate: short destination matrix is rangecheck) erris
+{ 2 2 [0 0 0] scale } /rangecheck (scale: short destination matrix is rangecheck) erris
+{ 1 1 [0 0 0 0 0] translate } /rangecheck (translate: short destination matrix is rangecheck) erris
+{ [1 0 0 1 0 0] [1 0 0 1 0 0] [1 2 3] concatmatrix } /rangecheck (concatmatrix: short destination is rangecheck) erris
+
 % --- transform / itransform round-trip with an explicit matrix ---
 10 20 [2 0 0 3 5 7] transform /ty exch def /tx exch def
 tx 25.0 (transform x) assertnear ty 67.0 (transform y) assertnear

--- a/tests/op_matrix_gstate_test.ps
+++ b/tests/op_matrix_gstate_test.ps
@@ -77,6 +77,16 @@ save1 setmatrix matrix currentmatrix 0 get save1 0 get (currentmatrix restored) 
 3.5 setlinewidth currentlinewidth 3.5 sub abs 1e-3 lt (setlinewidth) assert
 0.8 setflat currentflat 0.8 sub abs 1e-3 lt (setflat) assert
 
+% --- setdash validates the dash pattern (PLRM) ---
+{ [1 -2] 0 setdash } /rangecheck (setdash: a negative element is rangecheck) erris
+{ [0 0] 0 setdash }  /rangecheck (setdash: an all-zero array is rangecheck) erris
+{ [0] 0 setdash }    /rangecheck (setdash: a single zero is rangecheck) erris
+{ [0 1] 0 setdash } stopped not (setdash: one positive element is accepted) assert
+{ [] 0 setdash } stopped not (setdash: an empty array is accepted) assert
+{ [1 2] -5 setdash } stopped not (setdash: a negative offset is accepted) assert
+[3 2] 1 setdash currentdash exch pop 1.0 sub abs 1e-3 lt (setdash offset roundtrips) assert
+[] 0 setdash
+
 % --- gsave/grestore restores a parameter ---
 5 setmiterlimit gsave 9 setmiterlimit grestore
 currentmiterlimit 5 sub abs 1e-3 lt (grestore restores miterlimit) assert

--- a/tests/op_matrix_gstate_test.ps
+++ b/tests/op_matrix_gstate_test.ps
@@ -1,0 +1,47 @@
+% Matrix/coordinate and graphics-state operator compliance (PLRM 8.2), run through
+% `xpost -d null` by run-ps-test.sh: prints SUCCESS iff every assertion holds.
+% Standard PostScript; prints SUCCESS on Ghostscript too.
+%
+% Regression for campaign fixes:
+%   - transform/dtransform/itransform/idtransform with a matrix that is not a
+%     six-element array raised no error and read out of bounds; PLRM: rangecheck
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+/assertnear { 3 1 roll sub abs 1e-3 lt exch assert } def
+/erris { 3 dict begin /tag exch def /want exch def
+    stopped { $error /errorname get want eq }{ false } ifelse
+    tag assert clear end } def
+
+initgraphics
+
+% --- a bad-length matrix is rangecheck (was an out-of-bounds read) ---
+{ 10 20 [1 0 0 1] transform }   /rangecheck (transform: short matrix is rangecheck) erris
+{ 10 20 [1 2 3 4 5 6 7] transform } /rangecheck (transform: long matrix is rangecheck) erris
+{ 10 20 [1 0 0 1] dtransform }  /rangecheck (dtransform: short matrix is rangecheck) erris
+{ 25 67 [1 0 0 1] itransform }  /rangecheck (itransform: short matrix is rangecheck) erris
+{ 20 60 [1 0 0 1] idtransform } /rangecheck (idtransform: short matrix is rangecheck) erris
+{ [1 0 0 1] matrix invertmatrix } /rangecheck (invertmatrix: short matrix is rangecheck) erris
+
+% --- transform / itransform round-trip with an explicit matrix ---
+10 20 [2 0 0 3 5 7] transform /ty exch def /tx exch def
+tx 25.0 (transform x) assertnear ty 67.0 (transform y) assertnear
+tx ty [2 0 0 3 5 7] itransform /iy exch def /ix exch def
+ix 10.0 (itransform recovers x) assertnear iy 20.0 (itransform recovers y) assertnear
+% dtransform ignores the translation
+10 20 [2 0 0 3 5 7] dtransform /dy exch def /dx exch def
+dx 20.0 (dtransform x, no translation) assertnear dy 60.0 (dtransform y) assertnear
+
+% --- matrix builders (check specific elements, preserving the matrix with dup) ---
+2 3 matrix translate dup 4 get 2.0 (translate sets tx) assertnear
+                     5 get 3.0 (translate sets ty) assertnear
+2 3 matrix scale dup 0 get 2.0 (scale sets xx) assertnear
+                 3 get 3.0 (scale sets yy) assertnear
+[1 2 3 4 5 6] [1 0 0 1 0 0] matrix concatmatrix 0 get 1.0 (concatmatrix identity) assertnear
+
+% --- currentmatrix / setmatrix round-trip ---
+matrix currentmatrix /save1 exch def
+[2 0 0 2 0 0] setmatrix matrix currentmatrix 0 get 2.0 (setmatrix took effect) assertnear
+save1 setmatrix matrix currentmatrix 0 get save1 0 get (currentmatrix restored) assertnear
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_matrix_gstate_test.ps
+++ b/tests/op_matrix_gstate_test.ps
@@ -5,6 +5,8 @@
 % Regression for campaign fixes:
 %   - transform/dtransform/itransform/idtransform with a matrix that is not a
 %     six-element array raised no error and read out of bounds; PLRM: rangecheck
+%   - setlinecap/setlinejoin outside 0..2, and setmiterlimit below 1, were
+%     accepted silently; PLRM: rangecheck
 
 /failcount 0 def
 /assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
@@ -43,5 +45,27 @@ dx 20.0 (dtransform x, no translation) assertnear dy 60.0 (dtransform y) assertn
 matrix currentmatrix /save1 exch def
 [2 0 0 2 0 0] setmatrix matrix currentmatrix 0 get 2.0 (setmatrix took effect) assertnear
 save1 setmatrix matrix currentmatrix 0 get save1 0 get (currentmatrix restored) assertnear
+
+% --- setlinecap / setlinejoin: 0..2 only ---
+0 setlinecap currentlinecap 0 eq (setlinecap 0) assert
+2 setlinecap currentlinecap 2 eq (setlinecap 2) assert
+{ 3 setlinecap }  /rangecheck (setlinecap 3 is rangecheck) erris
+{ -1 setlinecap } /rangecheck (setlinecap -1 is rangecheck) erris
+1 setlinejoin currentlinejoin 1 eq (setlinejoin 1) assert
+{ 3 setlinejoin } /rangecheck (setlinejoin 3 is rangecheck) erris
+
+% --- setmiterlimit: >= 1 ---
+10 setmiterlimit currentmiterlimit 10 sub abs 1e-3 lt (setmiterlimit 10) assert
+1 setmiterlimit currentmiterlimit 1 sub abs 1e-3 lt (setmiterlimit 1 is the boundary) assert
+{ 0.5 setmiterlimit } /rangecheck (setmiterlimit below 1 is rangecheck) erris
+{ 0 setmiterlimit }   /rangecheck (setmiterlimit 0 is rangecheck) erris
+
+% --- setlinewidth / setflat round-trips ---
+3.5 setlinewidth currentlinewidth 3.5 sub abs 1e-3 lt (setlinewidth) assert
+0.8 setflat currentflat 0.8 sub abs 1e-3 lt (setflat) assert
+
+% --- gsave/grestore restores a parameter ---
+5 setmiterlimit gsave 9 setmiterlimit grestore
+currentmiterlimit 5 sub abs 1e-3 lt (grestore restores miterlimit) assert
 
 failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_matrix_gstate_test.ps
+++ b/tests/op_matrix_gstate_test.ps
@@ -33,6 +33,16 @@ initgraphics
 { 1 1 [0 0 0 0 0] translate } /rangecheck (translate: short destination matrix is rangecheck) erris
 { [1 0 0 1 0 0] [1 0 0 1 0 0] [1 2 3] concatmatrix } /rangecheck (concatmatrix: short destination is rangecheck) erris
 
+% --- a non-number coordinate is a typecheck: the matrix form's higher arity
+%     must not turn it into a stackunderflow; too few operands still underflows ---
+{ (x) 2 transform }   /typecheck (transform: a non-number coordinate is typecheck) erris
+{ 2 (y) transform }   /typecheck (transform: a non-number ordinate is typecheck) erris
+{ (x) 2 dtransform }  /typecheck (dtransform: a non-number coordinate is typecheck) erris
+{ (x) 2 itransform }  /typecheck (itransform: a non-number coordinate is typecheck) erris
+{ (x) 2 idtransform } /typecheck (idtransform: a non-number coordinate is typecheck) erris
+{ 3 transform }       /stackunderflow (transform: a single operand is stackunderflow) erris
+{ transform }         /stackunderflow (transform: no operands is stackunderflow) erris
+
 % --- transform / itransform round-trip with an explicit matrix ---
 10 20 [2 0 0 3 5 7] transform /ty exch def /tx exch def
 tx 25.0 (transform x) assertnear ty 67.0 (transform y) assertnear

--- a/tests/op_packing_test.ps
+++ b/tests/op_packing_test.ps
@@ -34,5 +34,12 @@ false setpacking
 0 vmreclaim
 pk 6 eq (a packed procedure survives collection) assert
 
+% the packedarray operator validates its count like array does
+{ 1 2 -1 packedarray } stopped { $error /errorname get /rangecheck eq } { false } ifelse
+  (packedarray of a negative count is a rangecheck) assert
+clear
+1 2 3 3 packedarray length 3 eq
+  (packedarray builds an array of the requested length) assert
+
 false setpacking
 failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_packing_test.ps
+++ b/tests/op_packing_test.ps
@@ -1,0 +1,38 @@
+% Array packing mode (setpacking / currentpacking, PLRM 8.2), run through
+% `xpost -d null` by run-ps-test.sh. Standard PostScript; prints SUCCESS on
+% Ghostscript too. A packed array is read-only, so packing is observed through
+% wcheck rather than through the type, which differs between implementations.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+
+currentpacking not (currentpacking is initially false) assert
+true setpacking currentpacking (setpacking true is reported by currentpacking) assert
+
+% a procedure built while packing is on is read-only, executable, and runs
+{ 10 20 add } dup xcheck (a packed procedure is executable) assert
+dup wcheck not (a packed procedure is read-only) assert
+exec 30 eq (a packed procedure executes correctly) assert
+
+% with packing off a procedure is writable again
+false setpacking
+{ 10 20 add } wcheck (an unpacked procedure is writable) assert
+currentpacking not (setpacking false is reported) assert
+
+% the mode is save/restore-subject in both directions
+false setpacking
+save true setpacking restore
+currentpacking not (restore reverts packing set on within the save) assert
+true setpacking
+save false setpacking restore
+currentpacking (restore reverts packing cleared within the save) assert
+
+% a packed procedure survives garbage collection and still runs
+true setpacking
+/pk { 2 3 mul } def
+false setpacking
+0 vmreclaim
+pk 6 eq (a packed procedure survives collection) assert
+
+false setpacking
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_path_test.ps
+++ b/tests/op_path_test.ps
@@ -1,0 +1,56 @@
+% Path-construction operator compliance (PLRM 8.2), run through `xpost -d null` by
+% run-ps-test.sh: prints SUCCESS iff every assertion holds. Standard PostScript;
+% prints SUCCESS on Ghostscript too.
+%
+% Regression for the campaign fix: arc/arcn built endpoints through a truncated
+% RAD_PER_DEG, so an arc's bounding box missed the axis by ~1.5e-5.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+/assertnear { 3 1 roll sub abs 1e-3 lt exch assert } def
+/erris { 3 dict begin /tag exch def /want exch def
+    stopped { $error /errorname get want eq }{ false } ifelse tag assert clear end } def
+
+% --- currentpoint tracks moveto / lineto / relative moves ---
+initgraphics newpath 10 20 moveto currentpoint
+20 (moveto y) assertnear 10 (moveto x) assertnear
+initgraphics newpath 10 20 moveto 30 40 lineto currentpoint
+40 (lineto y) assertnear 30 (lineto x) assertnear
+initgraphics newpath 10 20 moveto 5 6 rmoveto currentpoint
+26 (rmoveto y) assertnear 15 (rmoveto x) assertnear
+initgraphics newpath 0 0 moveto 10 0 rlineto 0 10 rlineto currentpoint
+10 (rlineto y) assertnear 10 (rlineto x) assertnear
+
+% --- currentpoint with no current point is nocurrentpoint; likewise rlineto ---
+{ initgraphics newpath currentpoint } /nocurrentpoint (currentpoint with no point) erris
+{ initgraphics newpath 5 5 rlineto }  /nocurrentpoint (rlineto with no point) erris
+
+% pathbbox pushes llx lly urx ury (ury on top) -- pop in that reverse order
+/bbox4 { /ury exch def /urx exch def /lly exch def /llx exch def } def
+
+% --- pathbbox over a triangle ---
+initgraphics newpath 10 10 moveto 20 30 lineto 40 10 lineto pathbbox bbox4
+llx 10 (pathbbox llx) assertnear  lly 10 (pathbbox lly) assertnear
+urx 40 (pathbbox urx) assertnear  ury 30 (pathbbox ury) assertnear
+
+% --- arc (0..90 deg, centre 50 50, r 20): box is exactly [50 50 70 70] ---
+initgraphics newpath 50 50 20 0 90 arc pathbbox bbox4
+llx 50 (arc bbox llx on centre x) assertnear  lly 50 (arc bbox lly on centre y) assertnear
+urx 70 (arc bbox urx) assertnear  ury 70 (arc bbox ury) assertnear
+% arcn (0..90 the other way, i.e. 0 down to -270) reaches left and below centre
+initgraphics newpath 50 50 20 0 90 arcn pathbbox bbox4
+llx 30 (arcn bbox llx) assertnear  ury 70 (arcn bbox ury) assertnear
+
+% --- closepath returns to the subpath start ---
+initgraphics newpath 3 4 moveto 20 4 lineto 20 20 lineto closepath currentpoint
+4 (closepath returns to start y) assertnear 3 (closepath returns to start x) assertnear
+
+% --- flattenpath keeps the curve's bounding box ---
+initgraphics newpath 0 0 moveto 0 100 100 100 100 0 curveto flattenpath pathbbox bbox4
+llx 0 (flattened curve llx) assertnear  urx 100 (flattened curve urx) assertnear
+
+% --- pathbbox raises nocurrentpoint on an empty path ---
+{ initgraphics newpath pathbbox } /nocurrentpoint (pathbbox on an empty path is nocurrentpoint) erris
+
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_radix_test.ps
+++ b/tests/op_radix_test.ps
@@ -1,0 +1,25 @@
+% Radix number range (PLRM 3.2), run through `xpost -d null` by run-ps-test.sh.
+%
+% A radix number is unsigned and keeps the same twos-complement representation
+% in the integer type's width, and one that exceeds that width is a limitcheck.
+% This is specific to the 32-bit integer type and is adjudicated against Adobe
+% Distiller and PLRM (an interpreter with wider integers keeps larger values as
+% integers), so it is checked on xpost only, not compared to Ghostscript.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+/tok { token pop exch pop } def   % string -> its first token
+
+(16#FFFFFFFF) tok -1 eq (16#FFFFFFFF is -1 in twos complement) assert
+(16#80000000) tok -2147483648 eq (16#80000000 is INT_MIN) assert
+(16#7FFFFFFF) tok 2147483647 eq (16#7FFFFFFF is INT_MAX) assert
+(2#1111) tok 15 eq (binary radix) assert
+(8#777) tok 511 eq (octal radix) assert
+
+% exceeding the integer width is a limitcheck (scanned at run time via token)
+{ (16#1FFFFFFFF) token } stopped { $error /errorname get /limitcheck eq }{ false } ifelse
+(radix beyond the integer width is limitcheck) assert
+{ (2#100000000000000000000000000000000) token } stopped { $error /errorname get /limitcheck eq }{ false } ifelse
+(binary radix beyond the width is limitcheck) assert
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_status_test.ps
+++ b/tests/op_status_test.ps
@@ -1,0 +1,37 @@
+% status operator, both forms (PLRM 8.2), run through `xpost -d null` by
+% run-ps-test.sh: prints SUCCESS iff every assertion holds. Standard PostScript;
+% prints SUCCESS on Ghostscript too.
+%
+% Regression for the campaign fix: only the "file status bool" form existed; the
+% "(filename) status pages bytes referred created true | false" form raised
+% typecheck. The byte size is checked exactly; pages and the timestamps are
+% implementation-defined, so only their type and presence are asserted.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+
+% create a file of known size (10 bytes)
+/f (status.scratch) (w) file def
+f (0123456789) writestring
+f closefile
+
+% --- filename form on an existing file: five results, size exact ---
+(status.scratch) status
+{
+    4 array astore
+    dup 1 get 10 eq (status reports the file size in bytes) assert
+    dup 0 get type /integertype eq (status pages is an integer) assert
+    dup 2 get type /integertype eq (status referred is an integer) assert
+    3 get type /integertype eq (status created is an integer) assert
+}
+{ false (status returned false for an existing file) assert }
+ifelse
+
+% --- filename form on a missing file: false ---
+(no.such.file.zzzz) status not (status of a missing file is false) assert
+
+% --- file-object form still returns a boolean status ---
+(status.scratch) (r) file dup status exch closefile
+(status of an open file object is true) assert
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_userparams_test.ps
+++ b/tests/op_userparams_test.ps
@@ -1,0 +1,28 @@
+% User and system parameter operators (PLRM 8.2), run through `xpost -d null` by
+% run-ps-test.sh: prints SUCCESS iff every assertion holds. Standard PostScript;
+% prints SUCCESS on Ghostscript too.
+%
+% currentuserparams and currentsystemparams each return a dictionary of the
+% current parameters; setuserparams and setsystemparams accept a dictionary and
+% apply the parameters they recognise, ignoring any they do not.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+
+currentuserparams
+dup type /dicttype eq (currentuserparams returns a dictionary) assert
+dup /MaxOpStack known (currentuserparams reports MaxOpStack) assert
+/MaxOpStack get type /integertype eq (MaxOpStack is an integer) assert
+
+currentsystemparams
+type /dicttype eq (currentsystemparams returns a dictionary) assert
+
+% setuserparams applies known parameters and ignores unknown ones without error
+{ << /VMReclaim 0 /ThisIsNotAParam 123 >> setuserparams true }
+stopped { pop false } if (setuserparams accepts a mixed dictionary) assert
+
+% setsystemparams accepts a dictionary without error
+{ << /ThisIsNotAParam 1 >> setsystemparams true }
+stopped { pop false } if (setsystemparams accepts a dictionary) assert
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/op_vmreclaim_test.ps
+++ b/tests/op_vmreclaim_test.ps
@@ -1,0 +1,27 @@
+% vmreclaim (PLRM 8.2), run through `xpost -d null` by run-ps-test.sh. Standard
+% PostScript; prints SUCCESS on Ghostscript too.
+%
+% 2 vmreclaim (local and global) must reclaim the local VM at least as well as
+% 1 vmreclaim (local): allocating and discarding the same way under each, the
+% growth under 2 is no worse than under 1. This catches 2 being a no-op.
+
+/failcount 0 def
+/assert { exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse } def
+/vmused { vmstatus pop exch pop } def
+/churn { 1 1 120 { pop /d 30 dict def 0 1 40 { d exch dup put } for 100 array pop } for } def
+
+vmused /g1 exch def
+churn 1 vmreclaim churn 1 vmreclaim
+vmused g1 sub /grow1 exch def
+
+vmused /g2 exch def
+churn 2 vmreclaim churn 2 vmreclaim
+vmused g2 sub /grow2 exch def
+
+% under a working collector both are small and close; a no-op 2 would grow far more
+grow2 grow1 sub 300000 lt (2 vmreclaim reclaims local VM like 1 does) assert
+
+{ 5 array pop 1 vmreclaim 5 array pop 2 vmreclaim true } stopped { pop false } if
+(vmreclaim 1 and 2 run without error) assert
+
+failcount 0 eq { (SUCCESS) = } { (FAILURES: ) print failcount = } ifelse

--- a/tests/run-error-format-test.sh
+++ b/tests/run-error-format-test.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Meson/make-check wrapper: a top-level error in a job reports in the standard
+# Adobe form -- the error line
+#   %%[ Error: NAME; OffendingCommand: CMD ]%%
+# (note the space before the closing bracket) followed by the flush notice
+#   %%[ Flushing: rest of job (to end-of-file) will be ignored ]%%
+# while a clean quit or a self-caught error reports neither. The two lines were
+# verified byte-for-byte against Adobe Distiller.
+#   $1  path to the built xpost binary
+set -u
+xpost=$1
+tmp=${TMPDIR:-/tmp}/errfmt-$$
+trap 'rm -f "$tmp".err.ps "$tmp".ok.ps "$tmp".caught.ps' 0
+
+# 1. a top-level undefined error: the error line (with its trailing space)
+#    and then the flush notice
+printf 'mistypedname\n' > "$tmp".err.ps
+out=$("$xpost" -q -d null "$tmp".err.ps </dev/null 2>&1)
+printf '%s\n' "$out"
+printf '%s\n' "$out" | grep -Fq '%%[ Error: undefined; OffendingCommand: mistypedname ]%%' || exit 1
+printf '%s\n' "$out" | grep -Fq '%%[ Flushing: rest of job (to end-of-file) will be ignored ]%%' || exit 1
+
+# 2. a clean job that quits normally: no flush notice
+printf '(ok) = quit\n' > "$tmp".ok.ps
+out=$("$xpost" -q -d null "$tmp".ok.ps </dev/null 2>&1)
+printf '%s\n' "$out" | grep -Fq 'Flushing' && exit 1
+
+# 3. a job that catches its own error and completes: no flush notice
+printf '{ oops } stopped pop (done) = quit\n' > "$tmp".caught.ps
+out=$("$xpost" -q -d null "$tmp".caught.ps </dev/null 2>&1)
+printf '%s\n' "$out" | grep -Fq 'Flushing' && exit 1
+printf '%s\n' "$out" | grep -Fq 'done' || exit 1
+
+exit 0

--- a/tests/run-error-format-test.sh
+++ b/tests/run-error-format-test.sh
@@ -10,7 +10,7 @@
 set -u
 xpost=$1
 tmp=${TMPDIR:-/tmp}/errfmt-$$
-trap 'rm -f "$tmp".err.ps "$tmp".ok.ps "$tmp".caught.ps' 0
+trap 'rm -f "$tmp".err.ps "$tmp".ok.ps "$tmp".caught.ps "$tmp".cascade.ps' 0
 
 # 1. a top-level undefined error: the error line (with its trailing space)
 #    and then the flush notice
@@ -30,5 +30,13 @@ printf '{ oops } stopped pop (done) = quit\n' > "$tmp".caught.ps
 out=$("$xpost" -q -d null "$tmp".caught.ps </dev/null 2>&1)
 printf '%s\n' "$out" | grep -Fq 'Flushing' && exit 1
 printf '%s\n' "$out" | grep -Fq 'done' || exit 1
+
+# 4. a runaway error cascade -- an errordict handler that itself raises an
+#    error, so recovery never reaches `stop` -- must abort the job cleanly
+#    rather than spin until VM exhaustion. The meson/make-check timeout
+#    bounds the run, so a failure to abort surfaces as a test timeout.
+printf 'errordict /undefinedresult { 1 0 div } put 1 0 div\n' > "$tmp".cascade.ps
+out=$("$xpost" -q -d null "$tmp".cascade.ps </dev/null 2>&1)
+printf '%s\n' "$out" | grep -Fq 'runaway error cascade' || exit 1
 
 exit 0

--- a/tests/run-ps-test.sh
+++ b/tests/run-ps-test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Meson test wrapper: run the PLRM-example conformance suite (data/test.ps)
+# in the freshly built interpreter and pass iff it reports SUCCESS -- i.e.
+# the suite's internal failcount reached zero.
+#   $1  path to the built xpost binary
+#   $2  path to test.ps
+set -u
+xpost=$1
+script=$2
+out=$("$xpost" -q -d null "$script" </dev/null 2>&1)
+printf '%s\n' "$out"
+printf '%s\n' "$out" | grep -q '^SUCCESS$'

--- a/tests/save_restore_ctm_test.ps
+++ b/tests/save_restore_ctm_test.ps
@@ -1,0 +1,18 @@
+%!PS
+% save/restore and gsave/grestore must revert the CTM. scale/concat/rotate
+% modify the current-matrix array in place; that write must be backed up for
+% save/restore, or a transform set inside a save/gsave leaks past the restore
+% (which made dvips documents render text at a runaway scale). Prints SUCCESS
+% iff a point transforms identically before and after each bracket.
+/fail 0 def
+/chk { % (name)
+    10 20 transform /y1 exch def /x1 exch def
+    x0 x1 eq y0 y1 eq and not { /fail fail 1 add def (FAIL: ) print == }{ pop } ifelse
+} def
+/mark0 { 10 20 transform /y0 exch def /x0 exch def } def
+
+initgraphics mark0 save 7 3 scale restore (save/scale/restore) chk
+initgraphics mark0 gsave 45 rotate grestore (gsave/rotate/grestore) chk
+initgraphics mark0 save [2 0 0 2 5 5] concat restore (save/concat/restore) chk
+initgraphics mark0 save 4 4 scale save 2 2 scale restore restore (nested save/scale) chk
+fail 0 eq { (SUCCESS) = }{ (FAILURES: ) print fail = } ifelse

--- a/tests/save_restore_test.ps
+++ b/tests/save_restore_test.ps
@@ -1,0 +1,65 @@
+% Save/restore VM regression checks, run through `xpost -d null` by
+% run-ps-test.sh: prints SUCCESS iff every assertion holds.
+%
+% Guards the saverec entity-width defect: a saverec stored the source
+% and copy entity numbers of a saved composite in 16-bit `word` fields,
+% so once the interpreter had allocated more than 65535 entities the
+% copy entity number was truncated and `restore` reverted -- or the
+% collector marked -- the wrong allocation. The failure is silent data
+% corruption: the modification made under save survives the restore, or
+% an unrelated object is clobbered. These checks first drive the entity
+% count past 65536, then require save/restore to revert dicts and arrays
+% exactly. Strings are deliberately not exercised: PLRM specifies that
+% restore "resets the values of all composite objects in local VM, except
+% strings, to their state at the time of the save", so a put'd string
+% character is meant to survive restore.
+
+/faildict 2 dict def
+faildict /n 0 put
+/assert { % bool (name) . -
+    exch { pop } {
+        (FAIL: ) print print (\n) print
+        faildict /n 2 copy get 1 add put
+    } ifelse
+} bind def
+
+% --- drive the entity counter past 65536 with reachable allocations ---
+% (unreachable ones would be collected and their entity numbers reused)
+/j1 35000 array def
+/j2 35000 array def
+0 1 34999 { j1 exch 2 array put } for
+0 1 34999 { j2 exch 2 array put } for
+
+% --- dict reverts across save/restore ---
+/d 3 dict def
+d /a 1 put
+save
+    d /a 2 put
+    d /a get 2 eq (dict change is visible under save) assert
+restore
+d /a get 1 eq (dict reverts on restore past 65536 entities) assert
+
+% --- array reverts across save/restore ---
+/arr 4 array def
+arr 0 100 put
+save
+    arr 0 200 put
+restore
+arr 0 get 100 eq (array reverts on restore past 65536 entities) assert
+
+% --- nested save/restore reverts to the right level ---
+/e 3 dict def
+e /k 0 put
+save
+    e /k 1 put
+    save
+        e /k 2 put
+    restore
+    e /k get 1 eq (inner restore reverts to outer-save value) assert
+restore
+e /k get 0 eq (outer restore reverts to pre-save value) assert
+
+count 0 eq (operand stack is balanced) assert
+faildict /n get 0 eq { (SUCCESS\n) print } { faildict /n get =print ( failures\n) print } ifelse
+flush
+quit

--- a/tests/save_restore_test.ps
+++ b/tests/save_restore_test.ps
@@ -59,6 +59,30 @@ save
 restore
 e /k get 0 eq (outer restore reverts to pre-save value) assert
 
+% --- a dict that GROWS (dicgrow) under a save reverts cleanly ---
+% dicgrow moves the dict to a larger allocation, so the saved copy and the
+% live object end the save block at different addresses AND different sizes.
+% restore therefore has to exchange the whole storage identity (adr, sz and
+% used) between the two, not just the address: swapping the address alone
+% leaves the reverted dict claiming the grown byte count while pointing at
+% the smaller backup allocation, an entity whose range then overruns its
+% neighbours once it is freed and reused. The overrun only manifests with a
+% specific allocation adjacency (the multi-plate poster reproduces it under a
+% low GC threshold); what a small script can pin down is that the revert
+% itself is exact -- size and keys -- and survives a collection.
+/g 2 dict def  g /a 1 put
+save
+    g /b 2 put  g /c 3 put  g /d 4 put  g /e 5 put  g /f 6 put
+    g length 6 eq (grown dict is visible under save) assert
+restore
+g length 1 eq (grown dict reverts to its saved size) assert
+g /a known (its saved key survives) assert
+g /b known not (a key added under save is gone) assert
+% churn the collector over a fresh allocation load; the reverted dict must
+% read back intact rather than reflecting a stale grown-storage identity
+/blk 4000 array def 0 1 3999 { blk exch 3 array put } for
+g /a get 1 eq (the reverted dict is intact after a collection) assert
+
 count 0 eq (operand stack is balanced) assert
 faildict /n get 0 eq { (SUCCESS\n) print } { faildict /n get =print ( failures\n) print } ifelse
 flush

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -39,6 +39,26 @@ cfstash type /filetype eq (a stashed currentfile recalls as a file) assert
 { (0.5junk) cvr } stopped { pop true }{ false } ifelse
 (a glued suffix is no numeral) assert
 
+% cvs of a real produces the shortest decimal that reads back to the
+% same value, in the notation the reference interpreters use: fixed
+% between 1e-4 and 1e6, scientific outside, a whole value keeping its
+% .0. It once emitted full binary-float precision, and a large value
+% corrupted a digit.
+/st.cvsr { 40 string cvs } def
+3.14159 st.cvsr (3.14159) eq (a real formats to the shortest decimal) assert
+0.001 st.cvsr (0.001) eq (a small real keeps fixed notation) assert
+2.5 st.cvsr (2.5) eq (no trailing zeros) assert
+100000.0 st.cvsr (100000.0) eq (a whole real keeps its point below 1e6) assert
+1e6 st.cvsr (1e+06) eq (a large real turns scientific at 1e6) assert
+1e-5 st.cvsr (1e-05) eq (a tiny real turns scientific below 1e-4) assert
+0.0001 st.cvsr (0.0001) eq (1e-4 is the last fixed magnitude) assert
+% every formatted real reads back to the value it came from
+/st.roundtrips true def
+[ 3.14159 0.001 2.5 100000.0 0.5 0.1 42.0 1e10 1e-5 ] {
+    dup st.cvsr cvr ne { /st.roundtrips false def } if
+} forall
+st.roundtrips (a formatted real reads back to itself) assert
+
 % a source that ends inside a procedure is a syntax error, not an
 % endless scan: the scanner answers null at end of input and nowhere
 % else, a literal null in the text being a name

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -31,6 +31,20 @@ currentfile xcheck not (currentfile carries the literal attribute) assert
 /cfstash currentfile def
 cfstash type /filetype eq (a stashed currentfile recalls as a file) assert
 
+% --- get and put require an integer index for strings and arrays; a real
+%     index, or a real value for a string byte, is a typecheck ---
+(ab) 1 get 98 eq (string get by an integer index) assert
+{ (ab) 1.0 get } stopped { pop pop true }{ false } ifelse (a real string index is a typecheck in get) assert
+/st.co 2 string def
+st.co 0 65 put st.co 0 get 65 eq (string put by an integer index and value) assert
+{ st.co 0.0 65 put } stopped { pop pop pop true }{ false } ifelse (a real string index is a typecheck in put) assert
+{ st.co 0 65.0 put } stopped { pop pop pop true }{ false } ifelse (a real string value is a typecheck in put) assert
+[ 5 6 7 ] 1 get 6 eq (array get by an integer index) assert
+{ [ 5 6 7 ] 1.0 get } stopped { pop pop true }{ false } ifelse (a real array index is a typecheck in get) assert
+/st.ca 2 array def
+st.ca 1 42 put st.ca 1 get 42 eq (array put by an integer index) assert
+{ st.ca 1.0 42 put } stopped { pop pop pop true }{ false } ifelse (a real array index is a typecheck in put) assert
+
 % cvi and cvr read their string operands with the scanner's token
 % semantics: leading white space and anything past the numeral's end
 % are ignored, and a token that is not a numeral refuses

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -24,6 +24,13 @@ tmpf dup ne not (stdout object not-ne itself) assert
 { (%stderr) (w) file (semantics_test: stderr probe\n) writestring true } stopped
 { pop false } if (writestring to %stderr) assert
 
+% --- currentfile returns a literal file: programs stash it under a
+%     name and the later lookup must push the stashed file, not
+%     resume executing it ---
+currentfile xcheck not (currentfile carries the literal attribute) assert
+/cfstash currentfile def
+cfstash type /filetype eq (a stashed currentfile recalls as a file) assert
+
 % --- an end-of-line marker is one white-space delimiter ---
 (ab\r\ncd) token pop exch (cd) eq
     (a CRLF after a token is consumed as one marker) assert

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -1,0 +1,25 @@
+% Object-semantics regression checks, run through `xpost -d null` by
+% run-ps-test.sh: prints SUCCESS iff every assertion holds.
+%
+% Covers:
+%   - eq/ne on file objects compare the underlying stream (distinct
+%     streams are ne; an object is eq to itself)
+
+/failcount 0 def
+/assert { % bool (name) . -
+    exch { pop } { (FAIL: ) print print (\n) print /failcount failcount 1 add def } ifelse
+} def
+/assertnear { % val expected (name) . -
+    3 1 roll sub abs 0.001 lt exch assert
+} def
+
+% --- file object comparison ---
+/tmpf (%stdout) (w) file def
+/diskf (semantics.diskf) (w) file def  % a real disk file (portable: not /dev/null)
+diskf tmpf ne (disk file vs stdout are distinct) assert
+diskf dup eq (file object equals itself) assert
+tmpf dup ne not (stdout object not-ne itself) assert
+
+failcount 0 eq { (SUCCESS\n) print } { (FAILURES: ) print failcount 20 string cvs print (\n) print } ifelse
+flush
+quit

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -30,6 +30,12 @@ tmpf dup ne not (stdout object not-ne itself) assert
 (ab\rcd) token pop exch (cd) eq
     (a bare CR after a token is consumed alone) assert
 
+% --- the job server accepts exitserver ---
+countdictstack
+{ serverdict begin 0 exitserver } stopped not
+    (exitserver continues the job) assert
+countdictstack eq (exitserver unwinds the begun serverdict) assert
+
 failcount 0 eq { (SUCCESS\n) print } { (FAILURES: ) print failcount 20 string cvs print (\n) print } ifelse
 flush
 quit

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -39,6 +39,18 @@ cfstash type /filetype eq (a stashed currentfile recalls as a file) assert
 { (0.5junk) cvr } stopped { pop true }{ false } ifelse
 (a glued suffix is no numeral) assert
 
+% the string scanner reads octal escapes as the reference does: at
+% most three digits, and octal digits only, so 8 and 9 and any fourth
+% digit end the escape. == relies on this to reconstruct what it
+% escaped (checked exhaustively by fuzzing, not here)
+(\3770) length 2 eq (an octal escape stops after three digits) assert
+(\0000) length 2 eq (a full three-digit octal stops at the third) assert
+(\09) length 2 eq (8 and 9 are not octal digits) assert
+(\128) length 2 eq (a non-octal digit ends the escape) assert
+(\101) 0 get 65 eq (three octal digits decode) assert
+(\377) 0 get 255 eq (the high octal value decodes) assert
+(\0) 0 get 0 eq (a one-digit octal decodes) assert
+
 % cvs of a real produces the shortest decimal that reads back to the
 % same value, in the notation the reference interpreters use: fixed
 % between 1e-4 and 1e6, scientific outside, a whole value keeping its

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -31,6 +31,20 @@ currentfile xcheck not (currentfile carries the literal attribute) assert
 /cfstash currentfile def
 cfstash type /filetype eq (a stashed currentfile recalls as a file) assert
 
+% --- an end-of-line inside a string literal: escaped, it joins
+%     the lines; raw, it is one newline character, whichever of
+%     the three conventions wrote it ---
+(ab\
+cd) length 4 eq (an escaped CRLF joins the lines) assert
+(ab\cd) length 4 eq (an escaped bare CR joins the lines) assert
+(ab\
+cd) length 4 eq (an escaped LF joins the lines) assert
+(a
+b) dup length 3 eq exch 1 get 10 eq and
+(a raw CRLF reads as one newline) assert
+(ab) dup length 3 eq exch 1 get 10 eq and
+(a raw CR reads as one newline) assert
+
 % --- an end-of-line marker is one white-space delimiter ---
 (ab\r\ncd) token pop exch (cd) eq
     (a CRLF after a token is consumed as one marker) assert

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -37,6 +37,14 @@ cfstash type /filetype eq (a stashed currentfile recalls as a file) assert
 (ab\rcd) token pop exch (cd) eq
     (a bare CR after a token is consumed alone) assert
 
+% --- gcheck holds for simple objects; composites answer for their
+%     storage ---
+42 gcheck (an integer is a legal element of a global composite) assert
+/st.gname gcheck (a name is a simple object under gcheck) assert
+[ 1 2 ] gcheck not (a local array is not) assert
+currentglobal true setglobal [ 1 2 ] exch setglobal gcheck
+(a global array is) assert
+
 % --- the job server accepts exitserver ---
 countdictstack
 { serverdict begin 0 exitserver } stopped not

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -148,6 +148,17 @@ countdictstack
     (exitserver continues the job) assert
 countdictstack eq (exitserver unwinds the begun serverdict) assert
 
+% --- dict growth: inserting far past a small dict's capacity grows and
+% rehashes it in place, repeatedly. Regression for a heap-use-after-free
+% where a re-insertion that relocated the memory file left the grow's
+% source-table pointer dangling: every entry must survive the growths. ---
+/GD 4 dict def
+0 1 20000 { GD exch dup put } for
+GD length 20001 eq (a repeatedly grown dict keeps every entry) assert
+GD 0 get 0 eq (the first key survives dict growth) assert
+GD 12345 get 12345 eq (a middle key survives dict growth) assert
+GD 20000 get 20000 eq (the last key survives dict growth) assert
+
 failcount 0 eq { (SUCCESS\n) print } { (FAILURES: ) print failcount 20 string cvs print (\n) print } ifelse
 flush
 quit

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -24,6 +24,12 @@ tmpf dup ne not (stdout object not-ne itself) assert
 { (%stderr) (w) file (semantics_test: stderr probe\n) writestring true } stopped
 { pop false } if (writestring to %stderr) assert
 
+% --- an end-of-line marker is one white-space delimiter ---
+(ab\r\ncd) token pop exch (cd) eq
+    (a CRLF after a token is consumed as one marker) assert
+(ab\rcd) token pop exch (cd) eq
+    (a bare CR after a token is consumed alone) assert
+
 failcount 0 eq { (SUCCESS\n) print } { (FAILURES: ) print failcount 20 string cvs print (\n) print } ifelse
 flush
 quit

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -39,6 +39,20 @@ cfstash type /filetype eq (a stashed currentfile recalls as a file) assert
 { (0.5junk) cvr } stopped { pop true }{ false } ifelse
 (a glued suffix is no numeral) assert
 
+% $error carries the standard entries: recordstacks (settable to skip
+% the stack snapshot) and errorinfo, both present in the reference
+$error /recordstacks known $error /errorinfo known and
+($error carries recordstacks and errorinfo) assert
+$error /recordstacks get (recordstacks defaults on) assert
+$error /ostack null put
+$error /recordstacks false put
+{ 1 (s) add } stopped pop
+$error /ostack get null eq (recordstacks off skips the snapshot) assert
+$error /recordstacks true put
+{ 1 (s) add } stopped pop
+$error /ostack get type /arraytype eq (recordstacks on takes the snapshot) assert
+$error /newerror false put
+
 % == prints arrays and procedures with single-space separators and no
 % padding inside the brackets, and its per-level scope leaves the dict
 % stack as it found it however deep the nesting goes

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -20,6 +20,10 @@ diskf tmpf ne (disk file vs stdout are distinct) assert
 diskf dup eq (file object equals itself) assert
 tmpf dup ne not (stdout object not-ne itself) assert
 
+% --- %stderr is writable ---
+{ (%stderr) (w) file (semantics_test: stderr probe\n) writestring true } stopped
+{ pop false } if (writestring to %stderr) assert
+
 failcount 0 eq { (SUCCESS\n) print } { (FAILURES: ) print failcount 20 string cvs print (\n) print } ifelse
 flush
 quit

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -45,6 +45,11 @@ cfstash type /filetype eq (a stashed currentfile recalls as a file) assert
 currentglobal true setglobal [ 1 2 ] exch setglobal gcheck
 (a global array is) assert
 
+% --- bind terminates on a procedure that reaches itself ---
+/st.cyc [ 1 2 3 ] cvx def
+/st.cyc load 0 /st.cyc load put
+/st.cyc load bind type /arraytype eq (bind survives a cyclic procedure) assert
+
 % --- the job server accepts exitserver ---
 countdictstack
 { serverdict begin 0 exitserver } stopped not

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -31,18 +31,28 @@ currentfile xcheck not (currentfile carries the literal attribute) assert
 /cfstash currentfile def
 cfstash type /filetype eq (a stashed currentfile recalls as a file) assert
 
+% cvi and cvr read their string operands with the scanner's token
+% semantics: leading white space and anything past the numeral's end
+% are ignored, and a token that is not a numeral refuses
+(0.5\n) cvr 0.5 (cvr ignores what follows the numeral) assertnear
+(  16 pt) cvi 16 eq (cvi skips leading space and trailing text) assert
+{ (0.5junk) cvr } stopped { pop true }{ false } ifelse
+(a glued suffix is no numeral) assert
+
 % --- an end-of-line inside a string literal: escaped, it joins
 %     the lines; raw, it is one newline character, whichever of
 %     the three conventions wrote it ---
 (ab\
 cd) length 4 eq (an escaped CRLF joins the lines) assert
-(ab\cd) length 4 eq (an escaped bare CR joins the lines) assert
+(ab\
+cd) length 4 eq (an escaped bare CR joins the lines) assert
 (ab\
 cd) length 4 eq (an escaped LF joins the lines) assert
 (a
 b) dup length 3 eq exch 1 get 10 eq and
 (a raw CRLF reads as one newline) assert
-(ab) dup length 3 eq exch 1 get 10 eq and
+(a
+b) dup length 3 eq exch 1 get 10 eq and
 (a raw CR reads as one newline) assert
 
 % --- an end-of-line marker is one white-space delimiter ---

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -39,6 +39,13 @@ cfstash type /filetype eq (a stashed currentfile recalls as a file) assert
 { (0.5junk) cvr } stopped { pop true }{ false } ifelse
 (a glued suffix is no numeral) assert
 
+% == prints arrays and procedures with single-space separators and no
+% padding inside the brackets, and its per-level scope leaves the dict
+% stack as it found it however deep the nesting goes
+countdictstack /st.dsd exch def
+[ 1 [ 2 [ 3 4 ] ] (s) /n { add } ] ==
+countdictstack st.dsd eq (== balances the dict stack when nesting) assert
+
 % the string scanner reads octal escapes as the reference does: at
 % most three digits, and octal digits only, so 8 and 9 and any fourth
 % digit end the escape. == relies on this to reconstruct what it

--- a/tests/semantics_test.ps
+++ b/tests/semantics_test.ps
@@ -39,6 +39,21 @@ cfstash type /filetype eq (a stashed currentfile recalls as a file) assert
 { (0.5junk) cvr } stopped { pop true }{ false } ifelse
 (a glued suffix is no numeral) assert
 
+% a source that ends inside a procedure is a syntax error, not an
+% endless scan: the scanner answers null at end of input and nowhere
+% else, a literal null in the text being a name
+/st.f (semantics.scratch) (w) file def
+st.f (1 2 { 3 4) writestring st.f closefile
+{ (semantics.scratch) (r) file cvx exec } stopped
+{ $error /errorname get /syntaxerror eq }{ false } ifelse
+(a truncated procedure ends the scan) assert
+clear
+% a complete procedure still scans and runs
+/st.f (semantics.scratch) (w) file def
+st.f (/st.tp { 6 7 add } def) writestring st.f closefile
+(semantics.scratch) (r) file cvx exec
+st.tp 13 eq (a closed procedure scans and runs) assert
+
 % --- an end-of-line inside a string literal: escaped, it joins
 %     the lines; raw, it is one newline character, whichever of
 %     the three conventions wrote it ---


### PR DESCRIPTION
PLRM-conformance and memory-safety fixes to the interpreter core. No behaviour is changed except to bring it in line with the PostScript Language Reference Manual (PLRM), or to fix an outright crash or leak.

**PLRM error conditions.** Operators now raise the error the PLRM specifies instead of the one that happened to fall out of the C:

- a wrong-typed operand is a `typecheck`, not a `stackunderflow`
- `cvi` of an over-range real, a bad-length matrix operand, `repeat` of a negative count, and `sqrt` of a negative are each a `rangecheck`
- a zero divisor is `undefinedresult` (with no fault at the `INT_MIN` edge)
- a radix number beyond the integer width, an over-cap composite literal, and a full gsave stack are each a `limitcheck`
- oversized array/string/dict allocations `limitcheck` rather than corrupt VM

**Number and scanner semantics.** The tokenizer and conversions follow the PLRM's number syntax and width rules:

- an over-range integer literal becomes a real, not a wrapped integer
- `cvr`/`cvi` accept only PostScript number syntax; octal string escapes read at most three digits; a real formats as the shortest decimal that reads back
- `get`/`put` take an integer index only; `for` keeps an integer control value under a real limit; gstate/colour number parameters record as reals
- procedure-nesting recursion is capped; a scan ends when a procedure runs past the input

**Memory safety and robustness.** A cluster of leaks, unchecked allocations, and out-of-bounds paths:

- save/restore no longer leaks a save-record substack per level, nor a restored composite's backup copy; saverecs carry full entity numbers, not truncated words
- dict growth stays memory-safe with a defined key hash; VM byte-access and grow-failure paths are hardened, and a memory file refuses to grow past its addressable size
- null-checks added on the GC object memory, the roll scratch allocation, and the `-D` definition array; the composite interval bounds check is corrected; the stacks are bounded against runaway growth

**Path, clip, and graphics fixes.** Arc direction and quadrant splitting; clip survival on curved, noisy and degenerate paths; ring-hole subtraction through a bridge; the scanline intersection buffer grows as needed.

**Test suite.** 22 new PostScript conformance tests (`tests/*_test.ps`) plus two shell harnesses (`run-ps-test.sh`, `run-error-format-test.sh`) covering the above — error conditions, number/scanner semantics, save/restore, access
attributes, counttomark, and more — run under `make check` / `meson test`.
